### PR TITLE
docs: add project status badges on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # SGHI Commons
 
+[![CI](https://github.com/savannahghi/sghi-commons/actions/workflows/ci.yml/badge.svg)](https://github.com/savannahghi/sghi-commons/actions/workflows/ci.yml)
 [![pyversion](https://camo.githubusercontent.com/64bafa7ada773716674e93fd8fbaa3f681e1748865cdcb47cc373579079b767f/68747470733a2f2f696d672e736869656c64732e696f2f707970692f707976657273696f6e732f7365747570746f6f6c732e737667)](https://camo.githubusercontent.com/64bafa7ada773716674e93fd8fbaa3f681e1748865cdcb47cc373579079b767f/68747470733a2f2f696d672e736869656c64732e696f2f707970692f707976657273696f6e732f7365747570746f6f6c732e737667)
+[![Checked with pyright](https://microsoft.github.io/pyright/img/pyright_badge.svg)](https://microsoft.github.io/pyright/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Coverage Status](https://coveralls.io/repos/github/savannahghi/sghi-commons/badge.svg?branch=develop)](https://coveralls.io/github/savannahghi/sghi-commons?branch=develop)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/savannahghi/sghi-commons/blob/main/LICENSE)
 
 A collection of utilities and reusable components used throughout our Python
 projects. They include:


### PR DESCRIPTION
Add the following project status badges on the README:

- Project CI workflow status badge
- [Pyright](https://microsoft.github.io/pyright/#/) checked badge
- MIT License in use badge