### PR TITLE
feat: add the `sghi.dispatch` module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.287"
+    rev: "v0.0.292"
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,7 @@ nitpick_ignore = [
     ("py:class", "TracebackType"),  # Used as type annotation. Only available when type checking
     ("py:class", "concurrent.futures._base.Executor"),  # sphinx can't find it
     ("py:class", "concurrent.futures._base.Future"),  # sphinx can't find it
+    ("py:class", "sghi.dispatch._ST_contra"),  # private type annotations
     ("py:class", "sghi.task._IT"),  # private type annotations
     ("py:class", "sghi.task._OT"),  # private type annotations
     ("py:class", "sghi.utils.checkers._Comparable"),  # private type annotations
@@ -72,6 +73,7 @@ nitpick_ignore = [
     ("py:class", "sghi.utils.checkers._T"),  # private type annotations
     ("py:class", "sghi.utils.module_loading._T"),  # private type annotations
     ("py:class", "sghi.typing._CT_contra"),  # private type annotations
+    ("py:obj", "sghi.dispatch._ST_contra"),  # private type annotations
     ("py:obj", "sghi.disposable.decorators.not_disposed._P"),  # private type annotations
     ("py:obj", "sghi.disposable.decorators.not_disposed._R"),  # private type annotations
     ("py:obj", "sghi.task._IT"),  # private type annotations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ API Reference
 
      sghi.app
      sghi.config
+     sghi.dispatch
      sghi.disposable
      sghi.exceptions
      sghi.task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ test = [
     "pytest-forked~=1.6.0",
     "pytest-sugar~=0.9.7",
     "pytest-xdist~=3.3.1",
-    "ruff~=0.0.287",
+    "ruff~=0.0.292",
     "tomli~=2.0.1",
     "tox~=4.11.1",
     "tox-gh-actions~=3.1.3",
@@ -123,6 +123,12 @@ profile = "black"
 [tool.pyright]
 analyzeUnannotatedFunctions = true
 enableTypeIgnoreComments = true
+exclude = [
+    "**/.*",
+    "**/node_modules",
+    "**/__pycache__",
+    "build",
+]
 reportConstantRedefinition = "error"
 reportDeprecated = "warning"
 reportDuplicateImport = "error"

--- a/src/sghi/app.py
+++ b/src/sghi/app.py
@@ -18,11 +18,24 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Final
 
 from .config import Config, SettingInitializer
+from .dispatch import Dispatcher
 
 # =============================================================================
 # GLOBAL APPLICATION/TOOL CONSTANTS
 # =============================================================================
 
+
+dispatcher: Final[Dispatcher] = Dispatcher.of_proxy()
+"""The main application :class:`dispatcher<sghi.dispatch.Dispatcher>`.
+
+.. admonition:: Note: To application authors
+    :class: note
+
+    This value is set to an instance of :class:`sghi.dispatch.DispatcherProxy`-
+    enabling the default wrapped instance to be replaced with a more
+    appropriate value during application setup.
+
+"""
 
 conf: Final[Config] = Config.of_proxy()
 """The application configurations.

--- a/src/sghi/dispatch/__init__.py
+++ b/src/sghi/dispatch/__init__.py
@@ -1,0 +1,480 @@
+"""
+Multiple-producer-multiple-accept signal-dispatching *heavily* inspired by
+`PyDispatcher <https://grass.osgeo.org/grass83/manuals/libpython/pydispatch.html>`_
+and :doc:`Django dispatch<django:topics/signals>`
+"""
+from __future__ import annotations
+
+import logging
+import weakref
+from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
+from logging import Logger
+from threading import RLock
+from typing import (
+    TYPE_CHECKING,
+    Generic,
+    TypeGuard,
+    TypeVar,
+    final,
+)
+
+from ..utils import (
+    ensure_instance_of,
+    ensure_not_none,
+    ensure_optional_instance_of,
+    ensure_predicate,
+    type_fqn,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# =============================================================================
+# TYPES
+# =============================================================================
+
+
+_ST_contra = TypeVar("_ST_contra", bound="Signal", contravariant=True)
+
+Receiver = Callable[[_ST_contra], None]
+"""
+A `Receiver` is a callable object that accepts and processes
+:class:`signals<Signal>`. It should accept a ``Signal`` as its sole argument
+and return ``None``.
+"""
+
+
+# =============================================================================
+# INTERFACES
+# =============================================================================
+
+
+class Signal(metaclass=ABCMeta):
+    """An occurrence of interest.
+
+    This class serves as a base for defining custom ``Signal`` classes that
+    represent specific occurrences or events in an application.
+    """
+
+    __slots__ = ()
+
+
+class Dispatcher(metaclass=ABCMeta):
+    """
+    An abstract class defining the interface for a :class:`Signal` dispatcher.
+
+    ``Signal`` dispatchers are responsible for connecting and disconnecting
+    :class:`receivers<Receiver>` to signals of interest, as well as sending
+    signals to the registered receivers.
+
+    Receivers can be connected or disconnected to signals using the
+    :meth:`connect` and :meth:`disconnect` methods respectively. Once signals
+    occur, connected receivers can be notified using the :meth:`send` method.
+    New ``Dispatcher`` instances can be created using the :meth:`of` static
+    factory method.
+
+    .. tip::
+
+        Unless otherwise indicated, at runtime, there should be an instance of
+        this class at :attr:`sghi.app.dispatcher` ment to hold the main
+        ``Dispatcher`` for the executing application.
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    def connect(
+            self,
+            signal_type: type[_ST_contra],
+            receiver: Receiver[_ST_contra],
+            *,
+            weak: bool = True,
+    ) -> None:
+        """
+        Register a :class:`receiver<Receiver>` to be notified of occurrences of
+        the specific :class:`signal type<Signal>`.
+
+        :param signal_type: The type of ``Signal`` to connect the receiver to.
+        :param receiver: The ``Receiver`` function to connect.
+        :param weak: Whether to use weak references for the connection.
+            Defaults to ``True``.
+
+        :return: None.
+        """
+        ...
+
+    @abstractmethod
+    def disconnect(
+            self,
+            signal_type: type[_ST_contra],
+            receiver: Receiver[_ST_contra],
+    ) -> None:
+        """
+        Detach a :class:`Receiver` function from a specific :class:`Signal`
+        type.
+
+        .. admonition:: **To Implementors**
+            :class: note
+
+            The disconnect should detach the ``Receiver`` from this
+            ``Dispatcher`` regardless of whether the ``Receiver`` was connected
+            using weak references.
+
+        :param signal_type: The type of ``Signal`` to disconnect the receiver
+            from.
+        :param receiver: The ``Receiver`` function to disconnect.
+
+        :return: None.
+        """
+        ...
+
+    @abstractmethod
+    def send(self, signal: Signal, robust: bool = True) -> None:
+        """
+        Send a :class:`Signal` to all :class:`receivers<Receiver>`
+        connected/registered to receive signals of the given signal type.
+
+        If robust is set to ``False`` and a ``Receiver`` raises an error, the
+        error propagates back through send, terminating the dispatch loop. So
+        it's possible that all receivers won't be called if an error is raised.
+
+        :param signal: The ``Signal`` to send.
+        :param robust: Whether to handle errors robustly. Defaults to ``True``.
+
+        :return: None.
+        """
+        ...
+
+    @staticmethod
+    def of() -> Dispatcher:
+        """Create and return a new :class:`Dispatcher` instance.
+
+        .. admonition:: Info
+
+            The returned ``Dispatcher`` is threadsafe and uses weak references
+            on :class:`receivers<Receiver>` by default. This can be changed by
+            setting the ``weak`` parameter to ``False`` on the :meth:`connect`
+            method when registering a new receiver.
+
+        :return: A ``Dispatcher`` instance.
+        """
+        return _DispatcherImp()
+
+    @staticmethod
+    def of_proxy(
+            source_dispatcher: Dispatcher | None = None,
+    ) -> DispatcherProxy:
+        """
+        Create a :class:`DispatcherProxy` instance that wraps the given
+        ``Dispatcher`` instance.
+
+        If `source_dispatcher` is not given, it defaults to a value with
+        similar semantics to those returned by the :meth:`Dispatcher.of`
+        factory method.
+
+        :param source_dispatcher: An optional ``Dispatcher`` instance to be
+            wrapped by the returned ``DispatcherProxy`` instance. A default
+            will be provided if not specified.
+
+        :return: A ``DispatcherProxy`` instance.
+        """
+        return DispatcherProxy(
+            source_dispatcher or Dispatcher.of(),
+        )
+
+
+# =============================================================================
+# DECORATORS
+# =============================================================================
+
+
+class connect(Generic[_ST_contra]):  # noqa :N801
+    """
+    A decorator for registering :class:`receivers<Receiver>` to be notified
+    when :class:`signals<Signal>` occur.
+
+    This decorator simplifies the process of connecting a receiver function to
+    a specific signal type in a :class:`dispatcher<Dispatcher>`. It is used to
+    mark a function as a receiver and specify the associated signal type and
+    dispatcher.
+    """
+
+    __slots__ = ("_signal_type", "_dispatcher", "_weak")
+
+    def __init__(
+            self,
+            signal_type: type[_ST_contra],
+            *,
+            dispatcher: Dispatcher | None = None,
+            weak: bool = True,
+    ) -> None:
+        """Initialize a new instance of ``connect`` decorator.
+
+        :param signal_type: The type of ``Signal`` to connect the receiver to.
+        :param dispatcher: The ``Dispatcher`` instance to connect the receiver
+            in. If not provided, will default to the value of
+            :attr:`sghi.app.dispatcher`.
+        :param weak: Whether to use weak references for the connection.
+            Defaults to ``True``.
+        """
+        super().__init__()
+        from sghi.app import dispatcher as app_dispatcher
+
+        ensure_instance_of(value=signal_type, klass=type)
+        self._signal_type: type[_ST_contra] = signal_type
+        self._dispatcher: Dispatcher = ensure_optional_instance_of(
+            value=dispatcher,
+            klass=Dispatcher,
+        ) or app_dispatcher
+        self._weak: bool = weak
+
+    def __call__(self, f: Receiver[_ST_contra]) -> Receiver[_ST_contra]:
+        """
+        Attach a :class:`receiver<Receiver>` function to a :class:`Dispatcher`.
+
+        :param f: The function to be attached to a ``Dispatcher``.
+
+        :return: The decorated function.
+        """
+        ensure_not_none(f, "'f' MUST not be None.")
+
+        self._dispatcher.connect(self._signal_type, f, weak=self._weak)
+
+        return f
+
+
+# =============================================================================
+# DISPATCH IMPLEMENTATIONS
+# =============================================================================
+
+
+@final
+class DispatcherProxy(Dispatcher):
+    """
+    A :class:`Dispatcher` implementation that wraps other ``Dispatcher``
+    instances.
+
+    The main advantage is it allows for substitutions of ``Dispatcher`` values
+    without requiring references to a ``Dispatcher`` instance to change.
+    Changes to the wrapped ``Dispatcher`` instance can be made using the
+    :meth:`set_source` method.
+    """
+
+    __slots__ = ("_source_dispatcher",)
+
+    def __init__(self, source_dispatcher: Dispatcher) -> None:
+        """
+        Initialize a new :class:`DispatcherProxy` instance that wraps the
+        given source ``Dispatcher`` instance.
+
+        :param source_dispatcher: The ``Dispatcher`` instance to wrap. This
+            MUST be an instance ``Dispatcher``.
+
+        :raise TypeError: If ``source_dispatcher`` is not an instance of
+            ``Dispatcher``.
+        """
+        self._source_dispatcher: Dispatcher = ensure_instance_of(
+            value=source_dispatcher,
+            klass=Dispatcher,
+        )
+
+    def connect(
+            self,
+            signal_type: type[_ST_contra],
+            receiver: Receiver[_ST_contra],
+            *,
+            weak: bool = True,
+    ) -> None:
+        self._source_dispatcher.connect(signal_type, receiver, weak=weak)
+
+    def disconnect(
+            self,
+            signal_type: type[_ST_contra],
+            receiver: Receiver[_ST_contra],
+    ) -> None:
+        self._source_dispatcher.disconnect(signal_type, receiver)
+
+    def send(self, signal: Signal, robust: bool = True) -> None:
+        self._source_dispatcher.send(signal, robust)
+
+    def set_source(self, source_dispatcher: Dispatcher) -> None:
+        """
+        Change the :class:`dispatcher<Dispatcher>` instance wrapped by this
+        proxy.
+
+        :param source_dispatcher: The new source dispatcher to use. This MUST
+            be an instance of ``Dispatcher``.
+
+        :return: None.
+
+        :raise TypeError: If ``source_dispatcher`` is not an instance of
+            ``Dispatcher``.
+        """
+        self._source_dispatcher = ensure_instance_of(
+            value=source_dispatcher,
+            klass=Dispatcher,
+        )
+
+
+@final
+class _DispatcherImp(Dispatcher):
+    """The default implementation of the :class:`Dispatcher` interface."""
+
+    __slots__ = ("_receivers", "_lock", "_logger", "_has_dead_receivers")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._receivers: dict[
+            type[Signal], set[Receiver | weakref.ReferenceType[Receiver]],
+        ] = {}
+        self._lock: RLock = RLock()
+        self._logger: Logger = logging.getLogger(type_fqn(self.__class__))
+        self._has_dead_receivers: bool = False
+
+    def connect(
+            self,
+            signal_type: type[_ST_contra],
+            receiver: Receiver[_ST_contra],
+            *,
+            weak: bool = True,
+    ) -> None:
+        ensure_instance_of(
+            value=signal_type,
+            klass=type,
+            message="'signal_type' MUST be a type.",
+        )
+        ensure_predicate(
+            issubclass(signal_type, Signal),
+            message=(
+                f"'signal_type' MUST be a subclass of '{type_fqn(Signal)}'."
+            ),
+            exc_factory=TypeError,
+        )
+        ensure_not_none(receiver, "'receiver' MUST not be None.")
+        self._logger.debug("Connect receiver, '%s'.", type_fqn(receiver))
+        _receiver: Receiver[_ST_contra] | weakref.ReferenceType[Receiver[_ST_contra]]  # noqa: E501
+        _receiver = receiver
+        if weak:
+            ref = weakref.ref
+            receiver_object = receiver
+            # Check for bound methods
+            if hasattr(receiver, "__self__") and hasattr(receiver, "__func__"):
+                ref = weakref.WeakMethod
+                receiver_object = receiver.__self__
+            _receiver = ref(receiver)
+            weakref.finalize(receiver_object, self._mark_dead_receiver_present)
+        with self._lock:
+            self._clear_dead_receivers()
+            self._receivers.setdefault(signal_type, set()).add(_receiver)
+
+    def disconnect(
+            self,
+            signal_type: type[_ST_contra],
+            receiver: Receiver[_ST_contra],
+    ) -> None:
+        ensure_instance_of(
+            value=signal_type,
+            klass=type,
+            message="'signal_type' MUST be a type.",
+        )
+        ensure_predicate(
+            issubclass(signal_type, Signal),
+            message=(
+                f"'signal_type' MUST be a subclass of '{type_fqn(Signal)}'."
+            ),
+            exc_factory=TypeError,
+        )
+        ensure_not_none(receiver, "'receiver' MUST not be None.")
+        self._logger.debug("Disconnect receiver, '%s'.", type_fqn(receiver))
+        with self._lock:
+            self._clear_dead_receivers()
+            receivers = self._receivers.get(signal_type, set())
+            receivers.discard(receiver)
+            # Remove the receiver even if it was connected "weakly".
+            receivers.difference_update({
+                _receiver
+                for _receiver in filter(self._is_weak, receivers)
+                if _receiver() == receiver
+            })
+
+    def send(self, signal: Signal, robust: bool = True) -> None:
+        ensure_instance_of(signal, Signal)
+        for receiver in self._live_receivers(type(signal)):
+            try:
+                receiver(signal)
+            except Exception:
+                if not robust:
+                    raise
+                self._logger.exception(
+                    "Error executing receiver '%s'.", type_fqn(receiver),
+                )
+
+    def _clear_dead_receivers(self) -> None:
+        with self._lock:
+            if not self._has_dead_receivers:
+                return
+            for _signal_type, _receivers in self._receivers.items():
+                self._receivers[_signal_type].difference_update(
+                    set(filter(self._is_dead, _receivers)),
+                )
+            self._has_dead_receivers = False
+
+    def _live_receivers(
+            self,
+            signal_type: type[_ST_contra],
+    ) -> Iterable[Receiver[_ST_contra]]:
+        with self._lock:
+            self._clear_dead_receivers()
+            receivers: set[Receiver[_ST_contra] | weakref.ReferenceType[Receiver[_ST_contra]]]  # noqa: E501
+            receivers = self._receivers.get(signal_type, set())
+            return filter(
+                self._is_live, map(self._dereference_as_necessary, receivers),
+            )
+
+    def _mark_dead_receiver_present(self) -> None:
+        with self._lock:
+            self._has_dead_receivers = True
+
+    @staticmethod
+    def _dereference_as_necessary(
+            receiver: Receiver[_ST_contra] | weakref.ReferenceType[Receiver[_ST_contra]],  # noqa: E501
+    ) -> Receiver[_ST_contra] | None:
+        # Dereference, if weak reference
+        return (
+            receiver()
+            if isinstance(receiver, weakref.ReferenceType)
+            else receiver
+        )
+
+    @staticmethod
+    def _is_dead(receiver: Receiver | weakref.ReferenceType) -> bool:
+        r = receiver
+        return isinstance(r, weakref.ReferenceType) and r() is None
+
+    @staticmethod
+    def _is_live(
+            receiver: Receiver[_ST_contra] | None,
+    ) -> TypeGuard[Receiver[_ST_contra]]:
+        return receiver is not None
+
+    @staticmethod
+    def _is_weak(
+            receiver: Receiver[_ST_contra]
+                      | weakref.ReferenceType[Receiver[_ST_contra]],
+    ) -> TypeGuard[weakref.ReferenceType[Receiver[_ST_contra]]]:
+        return isinstance(receiver, weakref.ReferenceType)
+
+
+# =============================================================================
+# MODULE EXPORTS
+# =============================================================================
+
+
+__all__ = [
+    "Dispatcher",
+    "DispatcherProxy",
+    "Receiver",
+    "Signal",
+    "connect",
+]

--- a/test/sghi/app_tests.py
+++ b/test/sghi/app_tests.py
@@ -1,5 +1,6 @@
 import sghi.app
 from sghi.config import Config
+from sghi.dispatch import Dispatcher
 
 
 def test_conf_attribute() -> None:
@@ -8,3 +9,12 @@ def test_conf_attribute() -> None:
     """
 
     assert isinstance(sghi.app.conf, Config)
+
+
+def test_dispatcher_attribute() -> None:
+    """
+    :attr:`sghi.app.dispatcher` should not be ``None`` and of type
+    :class:`Dispatcher`.
+    """
+
+    assert isinstance(sghi.app.dispatcher, Dispatcher)

--- a/test/sghi/config_tests.py
+++ b/test/sghi/config_tests.py
@@ -270,7 +270,7 @@ class TestConfigProxy(TestCase):
 
         assert self._source_config.DB_PORT == 5432
         assert self._instance.DB_PORT == 5432
-        assert self._source_config.DB_PASSWORD == "s3c3r3PA55word!"  # noqa: S105, E501
+        assert self._source_config.DB_PASSWORD == "s3c3r3PA55word!"  # noqa: S105
         assert self._instance.DB_PASSWORD == "s3c3r3PA55word!"  # noqa: S105
 
     def test_dunder_getattr_fails_on_missing_setting(self) -> None:

--- a/test/sghi/dispatch_tests.py
+++ b/test/sghi/dispatch_tests.py
@@ -1,0 +1,436 @@
+import gc
+from dataclasses import dataclass, field
+from unittest import TestCase
+
+import pytest
+
+from sghi.dispatch import Dispatcher, DispatcherProxy, Signal, connect
+from sghi.utils import ensure_greater_or_equal, type_fqn
+
+# =============================================================================
+# TESTS HELPERS
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True, match_args=True)
+class CounterAdvanced(Signal):
+    current_value: int = field()
+    advanced_by: int = field()
+
+
+@dataclass(frozen=True, slots=True, match_args=True)
+class CounterExhausted(Signal):
+    max_count: int = field()
+
+
+@dataclass(frozen=True, slots=True, match_args=True)
+class CounterReset(Signal):
+    current_value: int = field()
+
+
+class Counter:
+
+    __slots__ = ("_current", "_max_count", "_dispatcher")
+
+    def __init__(self, max_count: int) -> None:
+        super().__init__()
+        ensure_greater_or_equal(max_count, 0)
+        self._max_count: int = max_count
+        self._current: int = 0
+        self._dispatcher: Dispatcher = Dispatcher.of()
+
+    def advance_counter(self, by: int = 1) -> int:
+        ensure_greater_or_equal(by, 1, "MUST advance by at least 1.")
+        if self._current >= self._max_count:
+            self._dispatcher.send(CounterExhausted(self._max_count))
+            return self._current
+
+        self._current += by
+        self._dispatcher.send(CounterAdvanced(self._current, by))
+        return self._current
+
+    def reset(self) -> None:
+        self._current = 0
+        self._dispatcher.send(CounterReset(self._current))
+
+    @property
+    def current_value(self) -> int:
+        return self._current
+
+    @property
+    def dispatcher(self) -> Dispatcher:
+        return self._dispatcher
+
+    @property
+    def max_count(self) -> int:
+        return self._max_count
+
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+
+class TestDispatcher(TestCase):
+    """
+    Tests for the :class:`Dispatcher` interface default implementations.
+    """
+
+    def test_of_factory_method_return_value(self) -> None:
+        """:meth:`Dispatcher.of` should return a ``Dispatch`` instance."""
+
+        assert isinstance(Dispatcher.of(), Dispatcher)
+
+    def test_of_proxy_factory_method_return_value(self) -> None:
+        """
+        :meth:`Dispatcher.of_proxy` should return a ``DispatcherProxy``
+        instance.
+        """
+
+        assert isinstance(Dispatcher.of_proxy(), DispatcherProxy)
+
+
+class TestDispatcherOf(TestCase):
+    """
+    Tests for the :class:`Dispatcher` implementation returned by the
+    :meth:`Dispatcher.of` factory method.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._instance: Dispatcher = Dispatcher.of()
+        self._counter_max_value: int = 10
+        self._counter: Counter = Counter(self._counter_max_value)
+
+    def test_connect_fails_on_non_type_signal_type_as_input(self) -> None:
+        """
+        :meth:`Dispatcher.connect` should raise a :exc:`TypeError` when
+        given a `signal_type` parameter that is not a type.
+        """
+        with pytest.raises(TypeError, match="MUST be a type") as exc_info:
+            self._instance.connect(
+                signal_type=CounterReset(0),  # type: ignore # not a type
+                receiver=self.on_counter_reset,
+            )
+
+        assert exc_info.value.args[0] == "'signal_type' MUST be a type."
+
+    def test_connect_fails_on_signal_type_not_signal_subclass(self) -> None:
+        """
+        :meth:`Dispatcher.connect` should raise a :exc:`TypeError` when
+        given a `signal_type` parameter that is not a subclass of
+        :class:`Signal`.
+        """
+        with pytest.raises(TypeError, match="MUST be a subclass") as exc_info:
+            self._instance.connect(
+                signal_type=str,  # type: ignore # not a type
+                receiver=self.on_counter_reset,
+            )
+
+        assert exc_info.value.args[0] == (
+                f"'signal_type' MUST be a subclass of '{type_fqn(Signal)}'."
+        )
+
+    def test_connect_fails_on_none_receiver_as_input_value(self) -> None:
+        """
+        :meth:`Dispatcher.connect` should raise a :exc:`ValueError` when given
+        a ``None`` value on the ``receiver`` parameter.
+        """
+        with pytest.raises(ValueError, match="MUST not be None"):
+            self._instance.connect(CounterAdvanced, None)  # type: ignore
+
+    def test_connect_side_effects_when_weak_is_set_to_false(self) -> None:
+        """
+        :meth:`Dispatcher.connect` should add a receiver and retain it even
+        when it would normally be garbage collected when the ``weak``
+        parameter is set to ``False``.
+        """
+        output: list[int] = []
+
+        def on_counter_advanced(signa: CounterAdvanced) -> None:
+            output.append(signa.current_value)
+
+        class OnCounterAdvance:
+            def execute(self, signal: CounterAdvanced) -> None:
+                output.append(signal.current_value)
+
+        self._counter.dispatcher.connect(
+            CounterAdvanced,
+            on_counter_advanced,
+            weak=False,
+        )
+        self._counter.dispatcher.connect(
+            CounterAdvanced,
+            OnCounterAdvance().execute,
+            weak=False,
+        )
+
+        del on_counter_advanced
+        gc.collect()
+
+        self._counter.advance_counter()
+
+        assert len(output) == 2
+        assert output[0] == 1
+        assert output[1] == 1
+
+    def test_connect_side_effects_when_weak_is_set_to_true(self) -> None:
+        """
+        :meth:`Dispatcher.connect` should add a receiver but automatically
+        remove it after garbage collection when the ``weak`` parameter is set
+        to ``True``.
+        """
+        output: list[int] = []
+
+        def on_counter_advanced(signa: CounterAdvanced) -> None:
+            output.append(signa.current_value)
+
+        class OnCounterAdvance:
+            def execute(self, signal: CounterAdvanced) -> None:
+                output.append(signal.current_value)
+
+        self._counter.dispatcher.connect(
+            CounterAdvanced,
+            on_counter_advanced,
+            weak=True,
+        )
+        self._counter.dispatcher.connect(
+            CounterAdvanced,
+            OnCounterAdvance().execute,
+            weak=True,
+        )
+
+        del on_counter_advanced
+        gc.collect()
+
+        self._counter.advance_counter()
+
+        assert len(output) == 0
+
+    def test_disconnect_fails_on_non_type_signal_type_as_input(self) -> None:
+        """
+        :meth:`Dispatcher.disconnect` should raise a :exc:`TypeError` when
+        given a `signal_type` parameter that is not a type.
+        """
+        with pytest.raises(TypeError, match="MUST be a type") as exc_info:
+            self._instance.disconnect(
+                signal_type=CounterReset(0),  # type: ignore # not a type
+                receiver=self.on_counter_reset,
+            )
+
+        assert exc_info.value.args[0] == "'signal_type' MUST be a type."
+
+    def test_disconnect_fails_on_signal_type_not_signal_subclass(self) -> None:
+        """
+        :meth:`Dispatcher.disconnect` should raise a :exc:`TypeError` when
+        given a `signal_type` parameter that is not a subclass of
+        :class:`Signal`.
+        """
+        with pytest.raises(TypeError, match="MUST be a subclass") as exc_info:
+            self._instance.disconnect(
+                signal_type=str,  # type: ignore # not a type
+                receiver=self.on_counter_reset,
+            )
+
+        assert exc_info.value.args[0] == (
+            f"'signal_type' MUST be a subclass of '{type_fqn(Signal)}'."
+        )
+
+    def test_disconnect_fails_on_none_receiver_as_input_value(self) -> None:
+        """
+        :meth:`Dispatcher.disconnect` should raise a :exc:`ValueError` when
+        given a ``None`` value on the ``receiver`` parameter.
+        """
+        with pytest.raises(ValueError, match="MUST not be None"):
+            self._instance.disconnect(CounterAdvanced, None)  # type: ignore
+
+    def test_disconnect_side_effects_when_weak_is_set_to_false(self) -> None:
+        """
+        :meth:`Dispatcher.disconnect` should remove a connected receiver even
+        when it was not connected weakly.
+        """
+        counter: Counter = self._counter
+        output: list[int] = []
+
+        @connect(CounterAdvanced, dispatcher=counter.dispatcher, weak=False)
+        def on_counter_advanced1(signa: CounterAdvanced) -> None:  # type: ignore
+            output.append(signa.current_value)
+
+        @connect(CounterAdvanced, dispatcher=counter.dispatcher, weak=False)
+        def on_counter_advanced2(signa: CounterAdvanced) -> None:
+            output.append(signa.current_value)
+
+        counter.advance_counter()
+        counter.dispatcher.disconnect(CounterAdvanced, on_counter_advanced2)
+        counter.advance_counter()  # Should result in 2 being added to output
+
+        assert len(output) == 3
+        assert output[0] == 1
+        assert output[1] == 1
+        assert output[2] == 2
+
+    def test_disconnect_side_effects_when_weak_is_set_to_true(self) -> None:
+        """
+        :meth:`Dispatcher.disconnect` should remove a connected receiver even
+        when it was connected weakly.
+        """
+        counter: Counter = self._counter
+        output: list[int] = []
+
+        @connect(CounterAdvanced, dispatcher=counter.dispatcher, weak=True)
+        def on_counter_advanced1(signa: CounterAdvanced) -> None:
+            output.append(signa.current_value)
+
+        @connect(CounterAdvanced, dispatcher=counter.dispatcher, weak=True)
+        def on_counter_advanced2(signa: CounterAdvanced) -> None:  # type: ignore
+            output.append(signa.current_value)
+
+        counter.advance_counter()
+        counter.dispatcher.disconnect(CounterAdvanced, on_counter_advanced1)
+        counter.advance_counter()  # Should result in 2 being added to output
+
+        assert len(output) == 3
+        assert output[0] == 1
+        assert output[1] == 1
+        assert output[2] == 2
+
+    def test_send_fails_when_signal_is_not_a_signal(self) -> None:
+        """
+        :method:`Dispatcher.send` should raise a :exc:`ValueError` when the
+        ``signal`` parameter is not an instance of :class:`Signal`.
+        """
+
+    def test_send_side_effects_when_robust_is_set_to_false(self) -> None:
+        """
+        :meth:`Dispatcher.send` should propagate any errors raised by
+        receivers.
+        """
+        @connect(CounterReset, dispatcher=self._instance, weak=False)
+        def on_counter_reset(signal: CounterReset) -> None:  # type: ignore
+            raise ZeroDivisionError
+
+        with pytest.raises(ZeroDivisionError):
+            self._instance.send(CounterReset(0), robust=False)
+
+    def test_send_side_effects_when_robust_is_set_to_true(self) -> None:
+        """
+        :meth:`Dispatcher.send` should silently discard any errors raised by
+        receivers.
+        """
+        output: list[int] = []
+
+        @connect(CounterReset, dispatcher=self._instance, weak=False)
+        def on_counter_reset1(signal: CounterReset) -> None:  # type: ignore
+            raise ZeroDivisionError
+
+        @connect(CounterReset, dispatcher=self._instance, weak=False)
+        def on_counter_reset2(signal: CounterReset) -> None:  # type: ignore
+            output.append(signal.current_value)
+
+        try:
+            self._instance.send(CounterReset(0), robust=True)
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"'send' raised an unexpected error: '{exc}'.")
+
+        assert len(output) == 1
+        assert output[0] == 0
+
+    @staticmethod
+    def on_counter_reset(signal: CounterReset) -> None:
+        ...
+
+
+class TestDispatcherProxy(TestCase):
+    """Tests for the :class:`DispatcherProxy` class."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._source_dispatcher: Dispatcher = Dispatcher.of()
+        self._instance: DispatcherProxy = DispatcherProxy(
+            self._source_dispatcher,
+        )
+
+    def test_init_fails_when_source_dispatcher_is_not_a_dispatcher(self) -> None:  # noqa: E501
+        """
+        :meth:`DispatcherProxy.__init__` should raise a :exc:`TypeError` when
+        the ``source_dispatcher`` parameter given is not an instance of
+        :class:`Dispatcher`.
+        """
+        with pytest.raises(TypeError, match="is not an instance of"):
+            DispatcherProxy(source_dispatcher=None)  # type: ignore
+
+        with pytest.raises(TypeError, match="is not an instance of"):
+            DispatcherProxy(source_dispatcher={})  # type: ignore
+
+    def test_connect_side_effects(self) -> None:
+        """
+        :meth:`DispatcherProxy.connect` should have similar side effects to the
+        wrapped `Dispatcher` instance.
+        """
+        output: list[int] = []
+
+        def on_counter_advanced(signa: CounterAdvanced) -> None:
+            output.append(signa.current_value)
+
+        class OnCounterAdvance:
+            def execute(self, signal: CounterAdvanced) -> None:
+                output.append(signal.current_value)
+
+        self._instance.connect(
+            CounterAdvanced,
+            on_counter_advanced,
+            weak=False,
+        )
+        self._instance.connect(
+            CounterAdvanced,
+            OnCounterAdvance().execute,
+            weak=True,
+        )
+
+        self._instance.send(CounterAdvanced(current_value=1, advanced_by=1))
+
+        del on_counter_advanced
+        gc.collect()
+
+        self._instance.send(CounterAdvanced(current_value=10, advanced_by=9))
+
+        assert len(output) == 2
+        assert output[0] == 1
+        assert output[1] == 10
+
+    def test_disconnect_side_effects(self) -> None:
+        """
+        :meth:`DispatcherProxy.disconnect` should have similar side effects to
+        the wrapped `Dispatcher` instance.
+        """
+        output: list[int] = []
+
+        @connect(CounterAdvanced, dispatcher=self._instance, weak=False)
+        def on_counter_advanced1(signa: CounterAdvanced) -> None:
+            output.append(signa.current_value)
+
+        @connect(CounterAdvanced, dispatcher=self._instance, weak=True)
+        def on_counter_advanced2(signa: CounterAdvanced) -> None:
+            output.append(signa.current_value)
+
+        self._instance.send(CounterAdvanced(current_value=1, advanced_by=1))
+
+        del on_counter_advanced2
+        gc.collect()
+
+        self._instance.disconnect(CounterAdvanced, on_counter_advanced1)
+        self._instance.send(CounterAdvanced(current_value=10, advanced_by=9))
+
+        assert len(output) == 2
+        assert output[0] == 1
+        assert output[1] == 1
+
+    def test_set_source_fails_when_source_dispatch_is_not_a_dispatcher(self) -> None:  # noqa: E501
+        """
+        :meth:`DispatcherProxy.set_source` should raise a :exc:`TypeError` when
+        the ``source_dispatcher`` parameter given is not an instance of
+        :class:`Dispatcher`.
+        """
+
+        with pytest.raises(TypeError, match="is not an instance of"):
+            self._instance.set_source(source_dispatcher=None)  # type: ignore


### PR DESCRIPTION
Add the `sghi.dispatch` module which contains a Multiple-producer-multiple-accept signal-dispatcher implementation heavily inspired by [PyDispatcher](https://grass.osgeo.org/grass83/manuals/libpython/pydispatch.html) and [Django dispatch](https://docs.djangoproject.com/en/dev/topics/signals/).

This allows components of an application to react to changes or important events on other components of the application.