### PR TITLE
feat: add the `sghi.registry` module

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ nitpick_ignore = [
     ("py:class", "_P"),  # type annotation only available when type checking
     ("py:class", "_RT"),  # type annotation only available when type checking
     ("py:class", "Chain[Any]"),  # Used as type annotation. Only available when type checking
+    ("py:class", "Signal"),  # Used as type annotation. Only available when type checking
     ("py:class", "TracebackType"),  # Used as type annotation. Only available when type checking
     ("py:class", "concurrent.futures._base.Executor"),  # sphinx can't find it
     ("py:class", "concurrent.futures._base.Future"),  # sphinx can't find it

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ API Reference
      sghi.dispatch
      sghi.disposable
      sghi.exceptions
+     sghi.registry
      sghi.task
      sghi.typing
      sghi.utils

--- a/src/sghi/app.py
+++ b/src/sghi/app.py
@@ -19,6 +19,7 @@ from typing import Any, Final
 
 from .config import Config, SettingInitializer
 from .dispatch import Dispatcher
+from .registry import Registry
 
 # =============================================================================
 # GLOBAL APPLICATION/TOOL CONSTANTS
@@ -36,6 +37,20 @@ dispatcher: Final[Dispatcher] = Dispatcher.of_proxy()
     appropriate value during application setup.
 
 """
+
+
+registry: Final[Registry] = Registry.of_proxy()
+"""The main application :class:`registry<sghi.registry.Registry>`.
+
+.. admonition:: Note: To application authors
+    :class: note
+
+    This value is set to an instance of :class:`sghi.registry.RegistryProxy`-
+    enabling the default wrapped instance to be replaced with a more
+    appropriate value during application setup.
+
+"""
+
 
 conf: Final[Config] = Config.of_proxy()
 """The application configurations.

--- a/src/sghi/dispatch/__init__.py
+++ b/src/sghi/dispatch/__init__.py
@@ -169,7 +169,7 @@ class Dispatcher(metaclass=ABCMeta):
         Create a :class:`DispatcherProxy` instance that wraps the given
         ``Dispatcher`` instance.
 
-        If `source_dispatcher` is not given, it defaults to a value with
+        If ``source_dispatcher`` is not given, it defaults to a value with
         similar semantics to those returned by the :meth:`Dispatcher.of`
         factory method.
 
@@ -269,7 +269,7 @@ class DispatcherProxy(Dispatcher):
         given source ``Dispatcher`` instance.
 
         :param source_dispatcher: The ``Dispatcher`` instance to wrap. This
-            MUST be an instance ``Dispatcher``.
+            MUST be an instance of ``Dispatcher``.
 
         :raise TypeError: If ``source_dispatcher`` is not an instance of
             ``Dispatcher``.

--- a/src/sghi/registry/__init__.py
+++ b/src/sghi/registry/__init__.py
@@ -1,0 +1,441 @@
+"""
+``Registry`` interface definition, implementing classes and helpers.
+"""
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, final
+
+from sghi.dispatch import Dispatcher, Signal
+from sghi.exceptions import SGHIError
+from sghi.utils import ensure_instance_of, ensure_not_none
+
+# =============================================================================
+# EXCEPTIONS
+# =============================================================================
+
+
+class NoSuchRegistryItemError(SGHIError, LookupError):
+    """Non-existent :class:`Registry` item access error.
+
+    This is raised when trying to access or delete an item that does not exist
+    in a ``Registry``.
+    """
+
+    def __init__(self, item_key: str, message: str | None = None) -> None:
+        """Initialize a ``NoSuchRegistryItemError`` with the given properties.
+
+        :param item_key: The key of the missing item.
+        :param message: An optional message for the resulting exception.
+            If none is provided, then a generic one is automatically generated.
+        """
+        self._item_key: str = ensure_not_none(
+            item_key,
+            "'item_key' MUST not be None.",
+        )
+        super().__init__(
+            message=message
+            or (
+                "Item with key '%s' does not exist in the registry."
+                % self._item_key
+            ),
+        )
+
+    @property
+    def item_key(self) -> str:
+        """Return the missing item's key whose attempted access resulted in
+        this exception being raised.
+
+        :return: The missing item's key.
+        """
+        return self._item_key
+
+
+# =============================================================================
+# SIGNALS
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True, match_args=True)
+class RegistryItemRemoved(Signal):
+    """Signal indicating the removal of an item from the :class:`Registry`.
+
+    This signal is emitted when an item is removed from the ``Registry``.
+    """
+
+    item_key: str = field()
+    """The key of the removed item."""
+
+
+@dataclass(frozen=True, slots=True, match_args=True)
+class RegistryItemSet(Signal):
+    """Signal indicating the setting of an item in the :class:`Registry`.
+
+    This signal is emitted when a new item is added or updated to the
+    ``Registry``.
+    """
+
+    item_key: str = field()
+    """The key of the set item."""
+
+    item_value: Any = field(repr=False)
+    """The value of the added item."""
+
+
+# =============================================================================
+# REGISTRY INTERFACE
+# =============================================================================
+
+
+class Registry(metaclass=ABCMeta):
+    """An interface representing a registry for storing key-value pairs.
+
+    A ``Registry`` allows for storage and retrieval of values using unique
+    keys. It supports basic dictionary-like operations and provides an
+    interface for interacting with registered items.
+
+    A ``Registry`` also comes bundled with a :class:`~sghi.dispatch.Dispatcher`
+    whose responsibility is to emit :class:`signals<Signal>` whenever changes
+    to the registry are made. It allows other components to subscribe to these
+    signals and react accordingly. This dispatcher is accessible using the
+    :attr:`~sghi.registry.Registry.dispatcher` property.
+
+    For a list of supported signals, see the
+    :attr:`~sghi.registry.Registry.dispatcher` property docs.
+
+    .. tip::
+
+        Unless otherwise indicated, at runtime, there should be an instance of
+        this class at :attr:`sghi.app.registry` ment to hold the main
+        ``Registry`` for the executing application/tool.
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    def __contains__(self, key: str) -> bool:
+        """Check if the registry contains an item with the specified key.
+
+        :param key: The key to check for.
+
+        :return: ``True`` if the key exists in the registry, ``False``
+            otherwise.
+        """
+        ...
+
+    @abstractmethod
+    def __delitem__(self, key: str) -> None:
+        """Remove an item from the registry using the specified key.
+
+        If successful, this will result in a :class:`RegistryItemRemoved`
+        signal being emitted.
+
+        :param key: The key of the item to remove.
+
+        :return: None.
+
+        :raises NoSuchRegistryItemError: If the key does not exist in the
+            registry.
+        """
+        ...
+
+    @abstractmethod
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        """
+        Retrieve the value associated with the specified key from the registry.
+
+        :param key: The key of the item to retrieve.
+
+        :return: The value associated with the key.
+
+        :raises NoSuchRegistryItemError: If the key does not exist in the
+            registry.
+        """
+        ...
+
+    @abstractmethod
+    def __setitem__(self, key: str, value: Any) -> None:  # noqa: ANN401
+        """Set the value associated with the specified key in the registry.
+
+        If successful, this will result in a :class:`RegistryItemSet`
+        signal being emitted.
+
+        :param key: The key of the item to set.
+        :param value: The value to associate with the key.
+
+        :return: None.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def dispatcher(self) -> Dispatcher:
+        """
+        Get the :class:`~sghi.dispatch.Dispatcher` associated with the
+        ``Registry``.
+
+        The dispatcher is responsible for emitting signals when items are added
+        or removed from the registry. It allows other components to subscribe
+        to these signals and react accordingly.
+
+        ----
+
+        **Supported Signals**
+
+        Each ``Registry`` implementation should at the very least support the
+        following signals:
+
+        - :class:`RegistryItemSet` - This signal is emitted when either a new
+          item is added to the ``Registry``, or an existing item updated. It
+          includes information about the item's key and value.
+        - :class:`RegistryItemRemoved` - This signal is emitted when an item is
+          removed from the registry. It includes information about the item's
+          key.
+
+        These signals provide a way for other parts of the application to react
+        to changes in the registry, making the system more dynamic and
+        responsive.
+
+
+        :return: The dispatcher instance associated with the registry.
+        """
+        ...
+
+    @abstractmethod
+    def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        """
+        Retrieve the value associated with the specified key from the
+        ``Registry``, with an optional default value if the key does not exist.
+
+        :param key: The key of the item to retrieve.
+
+        :param default: The default value to return if the key does not exist.
+            Defaults to ``None`` when not specified.
+
+        :return: The value associated with the key, or the default value.
+        """
+        ...
+
+    @abstractmethod
+    def pop(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        """
+        Remove and return the value associated with the specified key from the
+        ``Registry``, or the specified default if the key does not exist.
+
+        .. note::
+
+            A :class:`RegistryItemRemoved` signal will only be emitted
+            `if and only if` an item with the specified key existed in the
+            ``Registry`` and was thus removed.
+
+        :param key: The key of the item to remove.
+        :param default: The default value to return if the key does not exist.
+            Defaults to ``None`` when not specified.
+
+        :return: The value associated with the key, or the default value.
+        """
+        ...
+
+    @abstractmethod
+    def setdefault(self, key: str, value: Any) -> Any:  # noqa: ANN401
+        """
+        Retrieve the value associated with the specified key from the
+        ``Registry``, or set it if the key does not exist.
+
+        .. note::
+
+            A :class:`RegistryItemSet` signal will only be emitted
+            `if and only if` an item with the specified key does not exist in
+            the ``Registry`` and thus the new default value was set.
+
+        :param key: The key of the item to retrieve or set.
+        :param value: The value to associate with the key if it does not exist.
+
+        :return: The value associated with the key, or the newly set value.
+        """
+        ...
+
+    @staticmethod
+    def of(dispatcher: Dispatcher | None = None) -> Registry:
+        """Factory method to create ``Registry`` instances.
+
+        :param dispatcher: An optional ``Dispatcher`` instance to associate
+            with the registry. A new ``Dispatcher`` instance will be created if
+            not specified.
+
+        :return: A ``Registry`` instance.
+        """
+        return _RegistryImp(dispatcher=dispatcher or Dispatcher.of())
+
+    @staticmethod
+    def of_proxy(source_registry: Registry | None = None) -> RegistryProxy:
+        """
+        Create a :class:`RegistryProxy` instance that wraps the given
+        ``Registry`` instance.
+
+        If ``source_registry`` is not given, it defaults to a value with
+        similar semantics to those returned by the :meth:`Registry.of` factory
+        method.
+
+        :param source_registry: An optional ``Registry`` instance to be wrapped
+            by the returned ``RegistryProxy`` instance. A default will be
+            provided if not specified.
+
+        :return: A ``RegistryProxy`` instance.
+        """
+        return RegistryProxy(source_registry or Registry.of())
+
+
+# =============================================================================
+# REGISTRY IMPLEMENTATIONS
+# =============================================================================
+
+
+@final
+class RegistryProxy(Registry):
+    """
+    A :class:`Registry` implementation that wraps other ``Registry`` instances.
+
+    The main advantage is it allows for substitutions of ``Registry`` values
+    without requiring references to a ``Registry`` instance to change. Changes
+    to the wrapped ``Registry`` instance can be made using the
+    :meth:`set_source` method.
+    """
+
+    __slots__ = ("_source_registry",)
+
+    def __init__(self, source_registry: Registry) -> None:
+        """
+        Initialize a new :class:`RegistryProxy` instance that wraps the given
+        source ``Registry`` instance.
+
+        :param source_registry: The ``Registry`` instance to wrap. This MUST be
+            an instance of ``Registry``.
+
+        :raise TypeError: If ``source_registry`` is not an instance of
+            ``Registry``.
+        """
+        super().__init__()
+        self._source_registry: Registry = ensure_instance_of(
+            value=source_registry,
+            klass=Registry,
+        )
+
+    def __contains__(self, key: str) -> bool:
+        return self._source_registry.__contains__(key)
+
+    def __delitem__(self, key: str) -> None:
+        self._source_registry.__delitem__(key)
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        return self._source_registry.__getitem__(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:  # noqa: ANN401
+        self._source_registry.__setitem__(key, value)
+
+    @property
+    def dispatcher(self) -> Dispatcher:
+        return self._source_registry.dispatcher
+
+    def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        return self._source_registry.get(key, default=default)
+
+    def pop(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        return self._source_registry.pop(key, default=default)
+
+    def setdefault(self, key: str, value: Any) -> Any:  # noqa: ANN401
+        return self._source_registry.setdefault(key, value)
+
+    def set_source(self, source_registry: Registry) -> None:
+        """
+        Change the :class:`registry<Registry>` instance wrapped by this proxy.
+
+        :param source_registry: The new source registry to use. This MUST be an
+            instance of ``Registry``.
+
+        :return: None.
+
+        :raise TypeError: If ``source_registry`` is not an instance of
+            ``Registry``.
+        """
+        self._source_registry = ensure_instance_of(source_registry, Registry)
+
+
+@final
+class _RegistryImp(Registry):
+    """An implementation of the Registry interface."""
+
+    __slots__ = ("_dispatcher", "_items")
+
+    def __init__(self, dispatcher: Dispatcher) -> None:
+        super().__init__()
+        self._dispatcher: Dispatcher = ensure_instance_of(
+            value=dispatcher,
+            klass=Dispatcher,
+        )
+        self._items: dict[str, Any] = {}
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._items
+
+    def __delitem__(self, key: str) -> None:
+        ensure_not_none(key, "'key' MUST not be None.")
+        try:
+            del self._items[key]
+            self.dispatcher.send(RegistryItemRemoved(item_key=key))
+        except KeyError:
+            raise NoSuchRegistryItemError(item_key=key) from None
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        ensure_not_none(key, "'key' MUST not be None.")
+        try:
+            return self._items[key]
+        except KeyError:
+            raise NoSuchRegistryItemError(item_key=key) from None
+
+    def __setitem__(self, key: str, value: Any) -> None:  # noqa: ANN401
+        ensure_not_none(key, "'key' MUST not be None.")
+        self._items[key] = value
+        self.dispatcher.send(
+            RegistryItemSet(item_key=key, item_value=value),
+        )
+
+    @property
+    def dispatcher(self) -> Dispatcher:
+        return self._dispatcher
+
+    def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        ensure_not_none(key, "'key' MUST not be None.")
+        return self._items.get(key, default)
+
+    def pop(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        ensure_not_none(key, "'key' MUST not be None.")
+        try:
+            value = self._items.pop(key)
+            self._dispatcher.send(RegistryItemRemoved(item_key=key))
+            return value
+        except KeyError:
+            return default
+
+    def setdefault(self, key: str, value: Any) -> Any:  # noqa: ANN401
+        ensure_not_none(key, "'key' MUST not be None.")
+        try:
+            return self[key]
+        except LookupError:
+            self[key] = value
+            return value
+
+
+# =============================================================================
+# MODULE EXPORTS
+# =============================================================================
+
+
+__all__ = (
+    "NoSuchRegistryItemError",
+    "Registry",
+    "RegistryItemRemoved",
+    "RegistryItemSet",
+    "RegistryProxy",
+)

--- a/test/sghi/app_tests.py
+++ b/test/sghi/app_tests.py
@@ -1,6 +1,7 @@
 import sghi.app
 from sghi.config import Config
 from sghi.dispatch import Dispatcher
+from sghi.registry import Registry
 
 
 def test_conf_attribute() -> None:
@@ -18,3 +19,12 @@ def test_dispatcher_attribute() -> None:
     """
 
     assert isinstance(sghi.app.dispatcher, Dispatcher)
+
+
+def test_registry_attribute() -> None:
+    """
+    :attr:`sghi.app.registry` should not be ``None`` and of type
+    :class:`Registry`.
+    """
+
+    assert isinstance(sghi.app.registry, Registry)

--- a/test/sghi/registry_tests.py
+++ b/test/sghi/registry_tests.py
@@ -1,0 +1,519 @@
+from unittest import TestCase
+
+import pytest
+
+from sghi.dispatch import connect
+from sghi.registry import (
+    NoSuchRegistryItemError,
+    Registry,
+    RegistryItemRemoved,
+    RegistryItemSet,
+    RegistryProxy,
+)
+
+
+class TestRegistry(TestCase):
+    """
+    Tests of the :class:`Registry` interface default method implementations.
+    """
+
+    def test_of_factory_method_return_value(self) -> None:
+        """:meth:`Registry.of` should return a ``Registry`` instance."""
+
+        assert isinstance(Registry.of(), Registry)
+
+    def test_of_proxy_factory_method_return_value(self) -> None:
+        """
+        :meth:`Registry.of_proxy` should return a ``RegistryProxy`` instance.
+        """
+
+        assert isinstance(RegistryProxy.of_proxy(), RegistryProxy)
+
+
+class TestRegistryOf(TestCase):
+    """
+    Tests for the :class:`Registry` implementation returned by the
+    :meth:`Registry.of` factory method.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._instance: Registry = Registry.of()
+        self._instance["ITEM_KEY_1"] = "ITEM_VALUE_1"
+        self._instance["ITEM_KEY_2"] = "ITEM_VALUE_2"
+
+    def test_contains_magic_method_return_value(self) -> None:
+        """
+        :meth:`Registry.__contain__` should return ``True`` if an item with the
+        specified key exists in the registry or ``False`` otherwise.
+        """
+
+        assert "ITEM_KEY_1" in self._instance
+        assert "ITEM_KEY_2" in self._instance
+        assert "ITEM_KEY_3" not in self._instance
+
+    def test_delitem_magic_method_side_effects_on_existing_value(self) -> None:
+        """
+        :meth:`Registry.__delitem__` should remove the given item from the
+        registry if it is already present.
+        """
+
+        output: set[str] = set()
+
+        @connect(RegistryItemRemoved, dispatcher=self._instance.dispatcher)
+        def on_reg_item_removed(signal: RegistryItemRemoved) -> None:  # pyright: ignore
+            output.add(signal.item_key)
+
+        del self._instance["ITEM_KEY_1"]
+        del self._instance["ITEM_KEY_2"]
+
+        assert "ITEM_KEY_1" in output
+        assert "ITEM_KEY_2" in output
+        assert "ITEM_KEY_1" not in self._instance
+        assert "ITEM_KEY_2" not in self._instance
+
+    def test_delitem_magic_method_fails_on_missing_item(self) -> None:
+        """
+        :meth:`Registry.__delitem__` should raise a
+        :exc:`NoSuchRegistryItemError` when given an item that is non-existent
+        in the registry.
+        """
+
+        with pytest.raises(NoSuchRegistryItemError) as exc_info:
+            del self._instance["ITEM_KEY_3"]
+
+        assert exc_info.value.item_key == "ITEM_KEY_3"
+
+    def test_delitem_magic_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`Registry.__delitem__` should raise a :exc:`ValueError` when
+        given a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            del self._instance[item_key]
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_getitem_magic_method_return_value_on_existing_value(self) -> None:
+        """
+        :meth:`Registry.__getitem__` should return the value associated with
+        the given item from the registry if it is already present.
+        """
+
+        assert self._instance["ITEM_KEY_1"] == "ITEM_VALUE_1"
+        assert self._instance["ITEM_KEY_2"] == "ITEM_VALUE_2"
+
+    def test_getitem_magic_method_fails_on_missing_item(self) -> None:
+        """
+        :meth:`Registry.__getitem__` should raise a
+        :exc:`NoSuchRegistryItemError` when given a key of a non-existent item
+        in the registry.
+        """
+
+        with pytest.raises(NoSuchRegistryItemError) as exc_info:
+            value = self._instance["ITEM_KEY_3"]  # pyright: ignore  # noqa: F841
+
+        assert exc_info.value.item_key == "ITEM_KEY_3"
+
+    def test_getitem_magic_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`Registry.__getitem__` should raise a :exc:`ValueError` when
+        given a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            value = self._instance[item_key]  # pyright: ignore  # noqa: F841
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_setitem_magic_method_side_effects(self) -> None:
+        """
+        :meth:`Registry.__setitem__` should add an item in the registry or
+        update the value of an existing item.
+        """
+
+        output: dict[str, str] = {}
+
+        @connect(RegistryItemSet, dispatcher=self._instance.dispatcher)
+        def on_reg_item_set(signal: RegistryItemSet) -> None:  # pyright: ignore
+            output[signal.item_key] = signal.item_value
+
+        # Update existing item
+        self._instance["ITEM_KEY_1"] = "IV_1"
+        self._instance["ITEM_KEY_2"] = "IV_2"
+        # Set item
+        self._instance["ITEM_KEY_3"] = "IV_3"
+
+        assert self._instance["ITEM_KEY_1"] == output["ITEM_KEY_1"] == "IV_1"
+        assert self._instance["ITEM_KEY_2"] == output["ITEM_KEY_2"] == "IV_2"
+        assert self._instance["ITEM_KEY_3"] == output["ITEM_KEY_3"] == "IV_3"
+
+    def test_setitem_magic_method_fails_on_non_item_key(self) -> None:
+        """
+        :meth:`Registry.__setitem__` should raise a :exc:`ValueError` when
+        given a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            self._instance[item_key] = "ITEM_VALUE"
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_get_method_return_value(self) -> None:
+        """
+        :meth:`Registry.get` should return the value associated with the given
+        item from the registry if it is already present. It should return
+        ``None`` of the given default if the item is not in the registry.
+        """
+
+        assert self._instance.get("ITEM_KEY_1") == "ITEM_VALUE_1"
+        assert self._instance.get("ITEM_KEY_2") == "ITEM_VALUE_2"
+        assert self._instance.get("ITEM_KEY_3") is None
+        assert self._instance.get("ITEM_KEY_3", default="IV_3") == "IV_3"
+
+    def test_get_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`Registry.get` should raise a :exc:`ValueError` when given a
+        ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            value = self._instance.get(item_key)  # pyright: ignore  # noqa: F841
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_pop_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`Registry.pop` should raise a :exc:`ValueError` when given a
+        ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            value = self._instance.pop(item_key)  # pyright: ignore  # noqa: F841
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_pop_method_side_effects(self) -> None:
+        """
+        :meth:`Registry.pop` should remove and return the given item from the
+        registry if it is already present. If not, it should return ``None`` or
+        the given default.
+        """
+
+        output: set[str] = set()
+
+        @connect(RegistryItemRemoved, dispatcher=self._instance.dispatcher)
+        def on_reg_item_removed(signal: RegistryItemRemoved) -> None:  # pyright: ignore
+            output.add(signal.item_key)
+
+        assert self._instance.pop("ITEM_KEY_1") == "ITEM_VALUE_1"
+        assert self._instance.pop("ITEM_KEY_2") == "ITEM_VALUE_2"
+        assert self._instance.pop("ITEM_KEY_3") is None
+        assert self._instance.pop("ITEM_KEY_4", default="IV_4") == "IV_4"
+        assert "ITEM_KEY_1" in output
+        assert "ITEM_KEY_2" in output
+        assert "ITEM_KEY_3" not in output
+        assert "ITEM_KEY_4" not in output
+        assert "ITEM_KEY_1" not in self._instance
+        assert "ITEM_KEY_2" not in self._instance
+
+    def test_setdefault_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`Registry.setdefault` should raise a :exc:`ValueError` when given
+        a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            self._instance.setdefault(item_key, "VALUE")
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_setdefault_method_side_effects(self) -> None:
+        """
+        :meth:`Registry.setdefault` should retrieve the value associated with
+        the specified key from the registry, or set it if the key does not
+        exist.
+        """
+
+        output: dict[str, str] = {}
+
+        @connect(RegistryItemSet, dispatcher=self._instance.dispatcher)
+        def on_reg_item_set(signal: RegistryItemSet) -> None:  # pyright: ignore
+            output[signal.item_key] = signal.item_value
+
+        # Retrieve existing item
+        assert self._instance.setdefault("ITEM_KEY_1", "IV1") == "ITEM_VALUE_1"
+        assert self._instance.setdefault("ITEM_KEY_2", "IV2") == "ITEM_VALUE_2"
+        # Set item
+        assert self._instance.setdefault("ITEM_KEY_3", "IV3") == "IV3"
+
+        assert "ITEM_KEY_1" not in output
+        assert "ITEM_KEY_2" not in output
+        assert self._instance["ITEM_KEY_3"] == output["ITEM_KEY_3"] == "IV3"
+
+
+class TestRegistryProxy(TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._source_registry: Registry = Registry.of()
+        self._instance: RegistryProxy = RegistryProxy(self._source_registry)
+        self._instance["ITEM_KEY_1"] = "ITEM_VALUE_1"
+        self._instance["ITEM_KEY_2"] = "ITEM_VALUE_2"
+
+    def test_init_fails_when_source_registry_is_not_a_registry(self) -> None:
+        """
+        :meth:`RegistryProxy.__init__` should raise a :exc:`TypeError` when
+        the ``source_registry`` parameter given is not an instance of
+        :class:`Registry`.
+        """
+        with pytest.raises(TypeError, match="is not an instance of"):
+            RegistryProxy(source_registry=None)   # type: ignore
+
+        with pytest.raises(TypeError, match="is not an instance of"):
+            RegistryProxy(source_registry={})  # type: ignore
+
+    def test_contains_magic_method_return_value(self) -> None:
+        """
+        :meth:`RegistryProxy.__contain__` should return ``True`` if an item
+        with the specified key exists in the registry or ``False`` otherwise.
+        """
+
+        assert "ITEM_KEY_1" in self._instance
+        assert "ITEM_KEY_2" in self._instance
+        assert "ITEM_KEY_3" not in self._instance
+
+    def test_delitem_magic_method_side_effects_on_existing_value(self) -> None:
+        """
+        :meth:`RegistryProxy.__delitem__` should remove the given item from the
+        registry if it is already present.
+        """
+
+        output: set[str] = set()
+
+        @connect(RegistryItemRemoved, dispatcher=self._instance.dispatcher)
+        def on_reg_item_removed(signal: RegistryItemRemoved) -> None:  # pyright: ignore
+            output.add(signal.item_key)
+
+        del self._instance["ITEM_KEY_1"]
+        del self._instance["ITEM_KEY_2"]
+
+        assert "ITEM_KEY_1" in output
+        assert "ITEM_KEY_2" in output
+        assert "ITEM_KEY_1" not in self._instance
+        assert "ITEM_KEY_2" not in self._instance
+
+    def test_delitem_magic_method_fails_on_missing_item(self) -> None:
+        """
+        :meth:`RegistryProxy.__delitem__` should raise a
+        :exc:`NoSuchRegistryItemError` when given an item that is non-existent
+        in the registry.
+        """
+
+        with pytest.raises(NoSuchRegistryItemError) as exc_info:
+            del self._instance["ITEM_KEY_3"]
+
+        assert exc_info.value.item_key == "ITEM_KEY_3"
+
+    def test_delitem_magic_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`RegistryProxy.__delitem__` should raise a :exc:`ValueError` when
+        given a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            del self._instance[item_key]
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_getitem_magic_method_return_value_on_existing_value(self) -> None:
+        """
+        :meth:`RegistryProxy.__getitem__` should return the value associated
+        with the given item from the registry if it is already present.
+        """
+
+        assert self._instance["ITEM_KEY_1"] == "ITEM_VALUE_1"
+        assert self._instance["ITEM_KEY_2"] == "ITEM_VALUE_2"
+
+    def test_getitem_magic_method_fails_on_missing_item(self) -> None:
+        """
+        :meth:`RegistryProxy.__getitem__` should raise a
+        :exc:`NoSuchRegistryItemError` when given a key of a non-existent item
+        in the registry.
+        """
+
+        with pytest.raises(NoSuchRegistryItemError) as exc_info:
+            value = self._instance["ITEM_KEY_3"]  # pyright: ignore  # noqa: F841
+
+        assert exc_info.value.item_key == "ITEM_KEY_3"
+
+    def test_getitem_magic_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`RegistryProxy.__getitem__` should raise a :exc:`ValueError` when
+        given a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            value = self._instance[item_key]  # pyright: ignore  # noqa: F841
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_setitem_magic_method_side_effects(self) -> None:
+        """
+        :meth:`RegistryProxy.__setitem__` should add an item in the registry or
+        update the value of an existing item.
+        """
+
+        output: dict[str, str] = {}
+
+        @connect(RegistryItemSet, dispatcher=self._instance.dispatcher)
+        def on_reg_item_set(signal: RegistryItemSet) -> None:  # pyright: ignore
+            output[signal.item_key] = signal.item_value
+
+        # Update existing item
+        self._instance["ITEM_KEY_1"] = "IV_1"
+        self._instance["ITEM_KEY_2"] = "IV_2"
+        # Set item
+        self._instance["ITEM_KEY_3"] = "IV_3"
+
+        assert self._instance["ITEM_KEY_1"] == output["ITEM_KEY_1"] == "IV_1"
+        assert self._instance["ITEM_KEY_2"] == output["ITEM_KEY_2"] == "IV_2"
+        assert self._instance["ITEM_KEY_3"] == output["ITEM_KEY_3"] == "IV_3"
+
+    def test_setitem_magic_method_fails_on_non_item_key(self) -> None:
+        """
+        :meth:`RegistryProxy.__setitem__` should raise a :exc:`ValueError` when
+        given a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            self._instance[item_key] = "ITEM_VALUE"
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_get_method_return_value(self) -> None:
+        """
+        :meth:`RegistryProxy.get` should return the value associated with the
+        given item from the registry if it is already present. It should return
+        ``None`` of the given default if the item is not in the registry.
+        """
+
+        assert self._instance.get("ITEM_KEY_1") == "ITEM_VALUE_1"
+        assert self._instance.get("ITEM_KEY_2") == "ITEM_VALUE_2"
+        assert self._instance.get("ITEM_KEY_3") is None
+        assert self._instance.get("ITEM_KEY_3", default="IV_3") == "IV_3"
+
+    def test_get_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`RegistryProxy.get` should raise a :exc:`ValueError` when given
+        a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            value = self._instance.get(item_key)  # pyright: ignore  # noqa: F841
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_pop_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`RegistryProxy.pop` should raise a :exc:`ValueError` when given a
+        ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            value = self._instance.pop(item_key)  # pyright: ignore  # noqa: F841
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_pop_method_side_effects(self) -> None:
+        """
+        :meth:`RegistryProxy.pop` should remove and return the given item from
+        the registry if it is already present. If not, it should return
+        ``None`` or the given default.
+        """
+
+        output: set[str] = set()
+
+        @connect(RegistryItemRemoved, dispatcher=self._instance.dispatcher)
+        def on_reg_item_removed(signal: RegistryItemRemoved) -> None:  # pyright: ignore
+            output.add(signal.item_key)
+
+        assert self._instance.pop("ITEM_KEY_1") == "ITEM_VALUE_1"
+        assert self._instance.pop("ITEM_KEY_2") == "ITEM_VALUE_2"
+        assert self._instance.pop("ITEM_KEY_3") is None
+        assert self._instance.pop("ITEM_KEY_4", default="IV_4") == "IV_4"
+        assert "ITEM_KEY_1" in output
+        assert "ITEM_KEY_2" in output
+        assert "ITEM_KEY_3" not in output
+        assert "ITEM_KEY_4" not in output
+        assert "ITEM_KEY_1" not in self._instance
+        assert "ITEM_KEY_2" not in self._instance
+
+    def test_set_source_fails_when_source_register_is_not_a_registry(self) -> None:  # noqa: E501
+        """
+        :meth:`RegistryProxy.set_source` should raise a :exc:`TypeError` when
+        the ``source_registry`` parameter given is not an instance of
+        :class:`Registry`.
+        """
+
+        with pytest.raises(TypeError, match="is not an instance of"):
+            self._instance.set_source(source_registry=None)  # type: ignore
+
+    def test_setdefault_method_fails_on_none_item_key(self) -> None:
+        """
+        :meth:`RegistryProxy.setdefault` should raise a :exc:`ValueError` when
+        given a ``None`` item key.
+        """
+
+        item_key: str = None  # type: ignore
+
+        with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
+            self._instance.setdefault(item_key, "VALUE")
+
+        assert exc_info.value.args[0] == "'key' MUST not be None."
+
+    def test_setdefault_method_side_effects(self) -> None:
+        """
+        :meth:`RegistryProxy.setdefault` should retrieve the value associated
+        with the specified key from the registry, or set it if the key does not
+        exist.
+        """
+
+        output: dict[str, str] = {}
+
+        @connect(RegistryItemSet, dispatcher=self._instance.dispatcher)
+        def on_reg_item_set(signal: RegistryItemSet) -> None:  # pyright: ignore
+            output[signal.item_key] = signal.item_value
+
+        # Retrieve existing item
+        assert self._instance.setdefault("ITEM_KEY_1", "IV1") == "ITEM_VALUE_1"
+        assert self._instance.setdefault("ITEM_KEY_2", "IV2") == "ITEM_VALUE_2"
+        # Set item
+        assert self._instance.setdefault("ITEM_KEY_3", "IV3") == "IV3"
+
+        assert "ITEM_KEY_1" not in output
+        assert "ITEM_KEY_2" not in output
+        assert self._instance["ITEM_KEY_3"] == output["ITEM_KEY_3"] == "IV3"


### PR DESCRIPTION
Add the `sghi.registry` module which defines the `Registry` interface, implementing classes and helpers.

A `Registry` allows for storage and retrieval of values using unique keys. It supports basic dictionary-like operations and provides an interface for interacting with registered items.