### PR TITLE
chore(deps): add py3.12 support and drop py3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
       - name: Set up project using python ${{ matrix.python-version }}
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: pip
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,17 +11,21 @@ repos:
       - id: check-vcs-permalinks
       - id: check-yaml
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.292"
-    hooks:
-      - id: ruff
-        args: [ --fix, --exit-non-zero-on-fix ]
-
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.15.1
     hooks:
       - id: pyupgrade
-        args: ["--py310-plus"]
+        args:
+          - --py311-plus
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.3.3
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+          - --exit-non-zero-on-fix
+      - id: ruff-format
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools~=68.2.0",
-    "setuptools_scm[toml]~=7.1.0"
+    "setuptools~=69.2.0",
+    "setuptools_scm[toml]~=8.0.4"
 ]
 
 [project]
@@ -23,8 +23,8 @@ classifiers = [
     "Typing :: Typed"
 ]
 dependencies = [
-    "importlib-metadata>=6.8.0",
-    "typing-extensions>=4.7",
+    "importlib-metadata>=7.0.2",
+    "typing-extensions>=4.10.0",
 ]
 description = "A collection of utilities used throughout SGHI's Python projects."
 dynamic = ["version"]
@@ -36,22 +36,22 @@ maintainers = [
 ]
 name = "sghi-commons"
 readme = "README.md"
-requires-python = ">=3.10" # Support Python 3.10+.
+requires-python = ">=3.11" # Support Python 3.11+.
 
 [project.optional-dependencies]
 dev = [
-    "pre-commit~=3.4.0",
+    "pre-commit~=3.6.2",
 ]
 
 docs = [
-    "furo==2023.8.19",
+    "furo==2024.1.29",
     "jaraco.packaging~=9.4.0",
     "rst.linker~=2.4.0",
-    "Sphinx~=7.2.5",
+    "Sphinx~=7.2.6",
     "sphinx-favicon~=1.0.1",
     "sphinx-hoverxref~=1.3.0",
     "sphinx-inline-tabs~=2023.4.21",
-    "sphinx-lint~=0.6.8",
+    "sphinx-lint~=0.9.1",
     "sphinx-notfound-page~=1.0.0",
 ]
 
@@ -60,16 +60,15 @@ test = [
     "coveralls~=3.3.1",
     "factory-boy~=3.3.0",
     "packaging",
-    "pyright>=1.1.325",
-    "pytest~=7.4.1",
+    "pyright>=1.1.354",
+    "pytest~=8.1.1",
     "pytest-cov~=4.1.0",
     "pytest-forked~=1.6.0",
-    "pytest-sugar~=0.9.7",
-    "pytest-xdist~=3.3.1",
-    "ruff~=0.0.292",
-    "tomli~=2.0.1",
-    "tox~=4.11.1",
-    "tox-gh-actions~=3.1.3",
+    "pytest-sugar~=1.0.0",
+    "pytest-xdist~=3.5.0",
+    "ruff~=0.3.3",
+    "tox~=4.14.1",
+    "tox-gh-actions~=3.2.0",
 ]
 
 [project.urls]
@@ -80,7 +79,7 @@ repository = "https://github.com/savannahghi/sghi-commons.git"
 
 [tool.black]
 line-length = 79
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.coverage.html]
 directory = "coverage"
@@ -110,7 +109,6 @@ show_missing = true
 [tool.coverage.run]
 branch = true
 omit = [".tox/*", "docs/*", "test/*"]
-# include = ["src/**/*.py"]
 
 [tool.isort]
 extend_skip = "docs"
@@ -153,7 +151,7 @@ strictSetInference = true
 typeCheckingMode = "basic"
 
 [tool.pytest.ini_options]
-addopts = "--cov=sghi --cov-fail-under=100 --cov-report=html --cov-report=term-missing -n auto --junitxml='junitxml_report/report.xml' -vv --durations=10 --cache-clear"
+addopts = "--cov=src/sghi --cov-fail-under=100 --cov-report=html --cov-report=term-missing -n auto --junitxml='junitxml_report/report.xml' -vv --durations=10 --cache-clear"
 console_output_style = "progress"
 log_cli = 1
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
@@ -181,15 +179,29 @@ exclude = [
     "node_modules",
     "venv",
 ]
+line-length = 79
+src = ["src", "test"]
+target-version = "py311"
+
+[tool.ruff.format]
+docstring-code-format = true
+indent-style = "space"
+quote-style = "double"
+skip-magic-trailing-comma = false
+
+[tool.ruff.lint]
 ignore = [
     "ANN002",
     "ANN003",
     "ANN101",
     "ANN102",
     "ANN204",
-    "S101"
+    "COM812",
+    "D203",
+    "D213",
+    "ISC001",
+    "S101",
 ]
-line-length = 79
 select = [
     "A",   # flake8-builtins
     "ANN", # flake8-annotations
@@ -222,17 +234,15 @@ select = [
     "W",   # pycodestyle Warning
     "YTT", # flake8-2020
 ]
-src = ["src", "test"]
-target-version = "py310"
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "double"
 docstring-quotes = "double"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["src", "test"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.setuptools]
@@ -248,7 +258,7 @@ root = "."
 [tool.tox]
 legacy_tox_ini = """
     [tox]
-    env_list = {py310, py311}, coveralls, docs, package
+    env_list = {py311, py312}, coveralls, docs, package
     isolated_build = true
     no_package = false
     requires =
@@ -258,13 +268,14 @@ legacy_tox_ini = """
 
     [gh-actions]
     python =
-        3.10: py310
-        3.11: py311, coveralls, docs, package
+        3.11: py311
+        3.12: py312, coveralls, docs, package
 
 
     [testenv]
     commands =
-        ruff .
+        ruff check .
+        ruff format --check .
         pyright .
         coverage erase
         pytest {posargs:.}

--- a/src/sghi/app.py
+++ b/src/sghi/app.py
@@ -1,5 +1,4 @@
-"""
-Global state definitions for SGHI applications.
+"""Global state definitions for SGHI applications.
 
 This module defines global properties important to an application. For all
 intents and purposes, these properties should be treated and thought of as
@@ -14,6 +13,7 @@ Applications should provide a valid implementation and monkey-patch it before
 first use. Whether multiple calls to the ``setup`` should be allowed is not
 defined and is left to the application implementors to decide.
 """
+
 from collections.abc import Mapping, Sequence
 from typing import Any, Final
 

--- a/src/sghi/dispatch/__init__.py
+++ b/src/sghi/dispatch/__init__.py
@@ -1,8 +1,8 @@
-"""
-Multiple-producer-multiple-accept signal-dispatching *heavily* inspired by
+"""Multiple-producer-multiple-accept signal-dispatching *heavily* inspired by
 `PyDispatcher <https://grass.osgeo.org/grass83/manuals/libpython/pydispatch.html>`_
 and :doc:`Django dispatch<django:topics/signals>`
 """
+
 from __future__ import annotations
 
 import logging
@@ -61,8 +61,8 @@ class Signal(metaclass=ABCMeta):
 
 
 class Dispatcher(metaclass=ABCMeta):
-    """
-    An abstract class defining the interface for a :class:`Signal` dispatcher.
+    """An abstract class defining the interface for a :class:`Signal`
+    dispatcher.
 
     ``Signal`` dispatchers are responsible for connecting and disconnecting
     :class:`receivers<Receiver>` to signals of interest, as well as sending
@@ -85,15 +85,14 @@ class Dispatcher(metaclass=ABCMeta):
 
     @abstractmethod
     def connect(
-            self,
-            signal_type: type[_ST_contra],
-            receiver: Receiver[_ST_contra],
-            *,
-            weak: bool = True,
+        self,
+        signal_type: type[_ST_contra],
+        receiver: Receiver[_ST_contra],
+        *,
+        weak: bool = True,
     ) -> None:
-        """
-        Register a :class:`receiver<Receiver>` to be notified of occurrences of
-        the specific :class:`signal type<Signal>`.
+        """Register a :class:`receiver<Receiver>` to be notified of occurrences
+        of the specific :class:`signal type<Signal>`.
 
         :param signal_type: The type of ``Signal`` to connect the receiver to.
         :param receiver: The ``Receiver`` function to connect.
@@ -106,12 +105,11 @@ class Dispatcher(metaclass=ABCMeta):
 
     @abstractmethod
     def disconnect(
-            self,
-            signal_type: type[_ST_contra],
-            receiver: Receiver[_ST_contra],
+        self,
+        signal_type: type[_ST_contra],
+        receiver: Receiver[_ST_contra],
     ) -> None:
-        """
-        Detach a :class:`Receiver` function from a specific :class:`Signal`
+        """Detach a :class:`Receiver` function from a specific :class:`Signal`
         type.
 
         .. admonition:: **To Implementors**
@@ -131,8 +129,7 @@ class Dispatcher(metaclass=ABCMeta):
 
     @abstractmethod
     def send(self, signal: Signal, robust: bool = True) -> None:
-        """
-        Send a :class:`Signal` to all :class:`receivers<Receiver>`
+        """Send a :class:`Signal` to all :class:`receivers<Receiver>`
         connected/registered to receive signals of the given signal type.
 
         If robust is set to ``False`` and a ``Receiver`` raises an error, the
@@ -163,10 +160,9 @@ class Dispatcher(metaclass=ABCMeta):
 
     @staticmethod
     def of_proxy(
-            source_dispatcher: Dispatcher | None = None,
+        source_dispatcher: Dispatcher | None = None,
     ) -> DispatcherProxy:
-        """
-        Create a :class:`DispatcherProxy` instance that wraps the given
+        """Create a :class:`DispatcherProxy` instance that wraps the given
         ``Dispatcher`` instance.
 
         If ``source_dispatcher`` is not given, it defaults to a value with
@@ -190,8 +186,7 @@ class Dispatcher(metaclass=ABCMeta):
 
 
 class connect(Generic[_ST_contra]):  # noqa :N801
-    """
-    A decorator for registering :class:`receivers<Receiver>` to be notified
+    """A decorator for registering :class:`receivers<Receiver>` to be notified
     when :class:`signals<Signal>` occur.
 
     This decorator simplifies the process of connecting a receiver function to
@@ -203,11 +198,11 @@ class connect(Generic[_ST_contra]):  # noqa :N801
     __slots__ = ("_signal_type", "_dispatcher", "_weak")
 
     def __init__(
-            self,
-            signal_type: type[_ST_contra],
-            *,
-            dispatcher: Dispatcher | None = None,
-            weak: bool = True,
+        self,
+        signal_type: type[_ST_contra],
+        *,
+        dispatcher: Dispatcher | None = None,
+        weak: bool = True,
     ) -> None:
         """Initialize a new instance of ``connect`` decorator.
 
@@ -223,15 +218,18 @@ class connect(Generic[_ST_contra]):  # noqa :N801
 
         ensure_instance_of(value=signal_type, klass=type)
         self._signal_type: type[_ST_contra] = signal_type
-        self._dispatcher: Dispatcher = ensure_optional_instance_of(
-            value=dispatcher,
-            klass=Dispatcher,
-        ) or app_dispatcher
+        self._dispatcher: Dispatcher = (
+            ensure_optional_instance_of(
+                value=dispatcher,
+                klass=Dispatcher,
+            )
+            or app_dispatcher
+        )
         self._weak: bool = weak
 
     def __call__(self, f: Receiver[_ST_contra]) -> Receiver[_ST_contra]:
-        """
-        Attach a :class:`receiver<Receiver>` function to a :class:`Dispatcher`.
+        """Attach a :class:`receiver<Receiver>` function to a
+        :class:`Dispatcher`.
 
         :param f: The function to be attached to a ``Dispatcher``.
 
@@ -251,8 +249,7 @@ class connect(Generic[_ST_contra]):  # noqa :N801
 
 @final
 class DispatcherProxy(Dispatcher):
-    """
-    A :class:`Dispatcher` implementation that wraps other ``Dispatcher``
+    """A :class:`Dispatcher` implementation that wraps other ``Dispatcher``
     instances.
 
     The main advantage is it allows for substitutions of ``Dispatcher`` values
@@ -264,8 +261,7 @@ class DispatcherProxy(Dispatcher):
     __slots__ = ("_source_dispatcher",)
 
     def __init__(self, source_dispatcher: Dispatcher) -> None:
-        """
-        Initialize a new :class:`DispatcherProxy` instance that wraps the
+        """Initialize a new :class:`DispatcherProxy` instance that wraps the
         given source ``Dispatcher`` instance.
 
         :param source_dispatcher: The ``Dispatcher`` instance to wrap. This
@@ -280,18 +276,18 @@ class DispatcherProxy(Dispatcher):
         )
 
     def connect(
-            self,
-            signal_type: type[_ST_contra],
-            receiver: Receiver[_ST_contra],
-            *,
-            weak: bool = True,
+        self,
+        signal_type: type[_ST_contra],
+        receiver: Receiver[_ST_contra],
+        *,
+        weak: bool = True,
     ) -> None:
         self._source_dispatcher.connect(signal_type, receiver, weak=weak)
 
     def disconnect(
-            self,
-            signal_type: type[_ST_contra],
-            receiver: Receiver[_ST_contra],
+        self,
+        signal_type: type[_ST_contra],
+        receiver: Receiver[_ST_contra],
     ) -> None:
         self._source_dispatcher.disconnect(signal_type, receiver)
 
@@ -299,8 +295,7 @@ class DispatcherProxy(Dispatcher):
         self._source_dispatcher.send(signal, robust)
 
     def set_source(self, source_dispatcher: Dispatcher) -> None:
-        """
-        Change the :class:`dispatcher<Dispatcher>` instance wrapped by this
+        """Change the :class:`dispatcher<Dispatcher>` instance wrapped by this
         proxy.
 
         :param source_dispatcher: The new source dispatcher to use. This MUST
@@ -326,18 +321,19 @@ class _DispatcherImp(Dispatcher):
     def __init__(self) -> None:
         super().__init__()
         self._receivers: dict[
-            type[Signal], set[Receiver | weakref.ReferenceType[Receiver]],
+            type[Signal],
+            set[Receiver | weakref.ReferenceType[Receiver]],
         ] = {}
         self._lock: RLock = RLock()
         self._logger: Logger = logging.getLogger(type_fqn(self.__class__))
         self._has_dead_receivers: bool = False
 
     def connect(
-            self,
-            signal_type: type[_ST_contra],
-            receiver: Receiver[_ST_contra],
-            *,
-            weak: bool = True,
+        self,
+        signal_type: type[_ST_contra],
+        receiver: Receiver[_ST_contra],
+        *,
+        weak: bool = True,
     ) -> None:
         ensure_instance_of(
             value=signal_type,
@@ -353,7 +349,9 @@ class _DispatcherImp(Dispatcher):
         )
         ensure_not_none(receiver, "'receiver' MUST not be None.")
         self._logger.debug("Connect receiver, '%s'.", type_fqn(receiver))
-        _receiver: Receiver[_ST_contra] | weakref.ReferenceType[Receiver[_ST_contra]]  # noqa: E501
+        _receiver: (
+            Receiver[_ST_contra] | weakref.ReferenceType[Receiver[_ST_contra]]
+        )
         _receiver = receiver
         if weak:
             ref = weakref.ref
@@ -369,9 +367,9 @@ class _DispatcherImp(Dispatcher):
             self._receivers.setdefault(signal_type, set()).add(_receiver)
 
     def disconnect(
-            self,
-            signal_type: type[_ST_contra],
-            receiver: Receiver[_ST_contra],
+        self,
+        signal_type: type[_ST_contra],
+        receiver: Receiver[_ST_contra],
     ) -> None:
         ensure_instance_of(
             value=signal_type,
@@ -392,11 +390,13 @@ class _DispatcherImp(Dispatcher):
             receivers = self._receivers.get(signal_type, set())
             receivers.discard(receiver)
             # Remove the receiver even if it was connected "weakly".
-            receivers.difference_update({
+            weak_receivers: set[weakref.ReferenceType[Receiver[_ST_contra]]]
+            weak_receivers = {  # pragma: no cover #  See: https://github.com/pytest-dev/pytest/issues/3689
                 _receiver
                 for _receiver in filter(self._is_weak, receivers)
                 if _receiver() == receiver
-            })
+            }
+            receivers.difference_update(weak_receivers)
 
     def send(self, signal: Signal, robust: bool = True) -> None:
         ensure_instance_of(signal, Signal)
@@ -407,7 +407,8 @@ class _DispatcherImp(Dispatcher):
                 if not robust:
                     raise
                 self._logger.exception(
-                    "Error executing receiver '%s'.", type_fqn(receiver),
+                    "Error executing receiver '%s'.",
+                    type_fqn(receiver),
                 )
 
     def _clear_dead_receivers(self) -> None:
@@ -421,15 +422,19 @@ class _DispatcherImp(Dispatcher):
             self._has_dead_receivers = False
 
     def _live_receivers(
-            self,
-            signal_type: type[_ST_contra],
+        self,
+        signal_type: type[_ST_contra],
     ) -> Iterable[Receiver[_ST_contra]]:
         with self._lock:
             self._clear_dead_receivers()
-            receivers: set[Receiver[_ST_contra] | weakref.ReferenceType[Receiver[_ST_contra]]]  # noqa: E501
+            receivers: set[
+                Receiver[_ST_contra]
+                | weakref.ReferenceType[Receiver[_ST_contra]]
+            ]
             receivers = self._receivers.get(signal_type, set())
             return filter(
-                self._is_live, map(self._dereference_as_necessary, receivers),
+                self._is_live,
+                map(self._dereference_as_necessary, receivers),
             )
 
     def _mark_dead_receiver_present(self) -> None:
@@ -438,7 +443,8 @@ class _DispatcherImp(Dispatcher):
 
     @staticmethod
     def _dereference_as_necessary(
-            receiver: Receiver[_ST_contra] | weakref.ReferenceType[Receiver[_ST_contra]],  # noqa: E501
+        receiver: Receiver[_ST_contra]
+        | weakref.ReferenceType[Receiver[_ST_contra]],
     ) -> Receiver[_ST_contra] | None:
         # Dereference, if weak reference
         return (
@@ -454,14 +460,14 @@ class _DispatcherImp(Dispatcher):
 
     @staticmethod
     def _is_live(
-            receiver: Receiver[_ST_contra] | None,
+        receiver: Receiver[_ST_contra] | None,
     ) -> TypeGuard[Receiver[_ST_contra]]:
         return receiver is not None
 
     @staticmethod
     def _is_weak(
-            receiver: Receiver[_ST_contra]
-                      | weakref.ReferenceType[Receiver[_ST_contra]],
+        receiver: Receiver[_ST_contra]
+        | weakref.ReferenceType[Receiver[_ST_contra]],
     ) -> TypeGuard[weakref.ReferenceType[Receiver[_ST_contra]]]:
         return isinstance(receiver, weakref.ReferenceType)
 

--- a/src/sghi/disposable/__init__.py
+++ b/src/sghi/disposable/__init__.py
@@ -1,6 +1,5 @@
-"""
-Resource disposal mixin, checks and other helpers.
-"""
+"""Resource disposal mixin, checks and other helpers."""
+
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
@@ -35,8 +34,7 @@ class ResourceDisposedError(SGHIError):
     """Indicates that a :class:`Disposable` item has already been disposed."""
 
     def __init__(self, message: str | None = "Resource already disposed."):
-        """
-        Initialize a new instance of `ResourceDisposedError`.
+        """Initialize a new instance of `ResourceDisposedError`.
 
         :param message: Optional custom error message. If not provided, a
             default message indicating that the resource is already disposed
@@ -63,7 +61,7 @@ class Disposable(AbstractContextManager, metaclass=ABCMeta):
 
     __slots__ = ()
 
-    def __exit__(
+    def __exit__(  # pyright: ignore[reportMissingSuperCall]
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
@@ -87,8 +85,7 @@ class Disposable(AbstractContextManager, metaclass=ABCMeta):
     @property
     @abstractmethod
     def is_disposed(self) -> bool:
-        """
-        Return ``True`` if this object has already been disposed, ``False``
+        """Return ``True`` if this object has already been disposed, ``False``
         otherwise.
 
         :return: ``True`` if this object has been disposed, ``False``
@@ -129,8 +126,7 @@ def not_disposed(
     f: Callable[Concatenate[_DT, _P], _RT],
     *,
     exc_factory: Callable[[], _DE] = ResourceDisposedError,
-) -> Callable[Concatenate[_DT, _P], _RT]:
-    ...
+) -> Callable[Concatenate[_DT, _P], _RT]: ...
 
 
 @overload
@@ -141,18 +137,20 @@ def not_disposed(
 ) -> Callable[
     [Callable[Concatenate[_DT, _P], _RT]],
     Callable[Concatenate[_DT, _P], _RT],
-]:
-    ...
+]: ...
 
 
 def not_disposed(
     f: Callable[Concatenate[_DT, _P], _RT] | None = None,
     *,
     exc_factory: Callable[[], _DE] = ResourceDisposedError,
-) -> Callable[Concatenate[_DT, _P], _RT] | Callable[
-    [Callable[Concatenate[_DT, _P], _RT]],
-    Callable[Concatenate[_DT, _P], _RT],
-]:
+) -> (
+    Callable[Concatenate[_DT, _P], _RT]
+    | Callable[
+        [Callable[Concatenate[_DT, _P], _RT]],
+        Callable[Concatenate[_DT, _P], _RT],
+    ]
+):
     """Decorate a function with the resource disposal check.
 
     This decorator ensures a :class:`Disposable` item has not been disposed. If
@@ -175,10 +173,10 @@ def not_disposed(
 
     :return: The decorated function.
     """
+
     def wrap(
         _f: Callable[Concatenate[_DT, _P], _RT],
     ) -> Callable[Concatenate[_DT, _P], _RT]:
-
         @wraps(_f)
         def wrapper(
             disposable: _DT,

--- a/src/sghi/exceptions.py
+++ b/src/sghi/exceptions.py
@@ -17,8 +17,7 @@ class SGHIError(Exception):
 
     @property
     def message(self) -> str | None:
-        """
-        Return the error message passed to this exception at initialization
+        """Return the error message passed to this exception at initialization
         or ``None`` if one was not given.
 
         :return: The error message passed to this exception at initialization

--- a/src/sghi/registry/__init__.py
+++ b/src/sghi/registry/__init__.py
@@ -1,6 +1,5 @@
-"""
-``Registry`` interface definition, implementing classes and helpers.
-"""
+"""``Registry`` interface definition, implementing classes and helpers."""
+
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
@@ -171,8 +170,7 @@ class Registry(metaclass=ABCMeta):
     @property
     @abstractmethod
     def dispatcher(self) -> Dispatcher:
-        """
-        Get the :class:`~sghi.dispatch.Dispatcher` associated with the
+        """Get the :class:`~sghi.dispatch.Dispatcher` associated with the
         ``Registry``.
 
         The dispatcher is responsible for emitting signals when items are added
@@ -204,8 +202,7 @@ class Registry(metaclass=ABCMeta):
 
     @abstractmethod
     def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
-        """
-        Retrieve the value associated with the specified key from the
+        """Retrieve the value associated with the specified key from the
         ``Registry``, with an optional default value if the key does not exist.
 
         :param key: The key of the item to retrieve.
@@ -219,9 +216,8 @@ class Registry(metaclass=ABCMeta):
 
     @abstractmethod
     def pop(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
-        """
-        Remove and return the value associated with the specified key from the
-        ``Registry``, or the specified default if the key does not exist.
+        """Remove and return the value associated with the specified key from
+        the ``Registry``, or the specified default if the key does not exist.
 
         .. note::
 
@@ -239,8 +235,7 @@ class Registry(metaclass=ABCMeta):
 
     @abstractmethod
     def setdefault(self, key: str, value: Any) -> Any:  # noqa: ANN401
-        """
-        Retrieve the value associated with the specified key from the
+        """Retrieve the value associated with the specified key from the
         ``Registry``, or set it if the key does not exist.
 
         .. note::
@@ -270,8 +265,7 @@ class Registry(metaclass=ABCMeta):
 
     @staticmethod
     def of_proxy(source_registry: Registry | None = None) -> RegistryProxy:
-        """
-        Create a :class:`RegistryProxy` instance that wraps the given
+        """Create a :class:`RegistryProxy` instance that wraps the given
         ``Registry`` instance.
 
         If ``source_registry`` is not given, it defaults to a value with

--- a/src/sghi/task/__init__.py
+++ b/src/sghi/task/__init__.py
@@ -1,6 +1,5 @@
-"""
-``Task`` interface definition together with its common implementations.
-"""
+"""``Task`` interface definition together with its common implementations."""
+
 from __future__ import annotations
 
 import warnings
@@ -22,7 +21,7 @@ from ..disposable import not_disposed as _nd_factory
 from ..utils import ensure_not_none, ensure_not_none_nor_empty, type_fqn
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing import Self
 
 # =============================================================================
 # TYPES
@@ -39,7 +38,7 @@ _OT = TypeVar("_OT")
 
 
 def _callables_to_tasks_as_necessary(
-        tasks: Sequence[Task[_IT, _OT] | Callable[[_IT], _OT]],
+    tasks: Sequence[Task[_IT, _OT] | Callable[[_IT], _OT]],
 ) -> Sequence[Task[_IT, _OT]]:
     """Convert callables to :class:`Task` instances if necessary.
 
@@ -72,8 +71,7 @@ class ConcurrentExecutorDisposedError(ResourceDisposedError):
     """
 
     def __init__(self, message: str | None = "ConcurrentExecutor disposed."):
-        """
-        Initialize a ``ConcurrentExecutorDisposedError`` with an optional
+        """Initialize a ``ConcurrentExecutorDisposedError`` with an optional
         message.
 
         :param message: An optional message for the exception.
@@ -177,8 +175,7 @@ class Chain(Task[Callable[[_IT], Any], "Chain[Any]"], Generic[_IT]):
         return self._value
 
     def execute(self, an_input: Callable[[_IT], _OT]) -> Chain[_OT]:
-        """
-        Perform the given transformation on the wrapped value and wrap the
+        """Perform the given transformation on the wrapped value and wrap the
         result in a new ``Chain`` instance.
 
         :param an_input: A callable defining a transformation to be applied to
@@ -205,8 +202,7 @@ class Consume(Task[_IT, _IT], Generic[_IT]):
     __slots__ = ("_accept",)
 
     def __init__(self, accept: Callable[[_IT], Any]) -> None:
-        """
-        Initialize a new :class:`Consume` instance that applies the given
+        """Initialize a new :class:`Consume` instance that applies the given
         action to it's inputs.
 
         :param accept: A callable to apply to this task's inputs. This MUST not
@@ -362,13 +358,12 @@ class ConcurrentExecutor(
     )
 
     def __init__(
-            self,
-            *tasks: Task[_IT, _OT] | Callable[[_IT], _OT],
-            wait_for_completion: bool = True,
-            executor: Executor | None = None,
+        self,
+        *tasks: Task[_IT, _OT] | Callable[[_IT], _OT],
+        wait_for_completion: bool = True,
+        executor: Executor | None = None,
     ):
-        """
-        Initialize a new `ConcurrentExecutor` instance with the given
+        """Initialize a new `ConcurrentExecutor` instance with the given
         properties.
 
         :param tasks: The tasks to be executed concurrently. This MUST not be
@@ -480,8 +475,8 @@ class ConcurrentExecutor(
 
     @staticmethod
     def _accumulate(
-            partial_results: MutableSequence[Future[_OT]],
-            task_output: Future[_OT],
+        partial_results: MutableSequence[Future[_OT]],
+        task_output: Future[_OT],
     ) -> MutableSequence[Future[_OT]]:
         partial_results.append(task_output)
         return partial_results

--- a/src/sghi/typing/__init__.py
+++ b/src/sghi/typing/__init__.py
@@ -1,14 +1,14 @@
-"""
-Useful typings for use with type annotations as defined by
+"""Useful typings for use with type annotations as defined by
 :doc:`PEP 484<peps:pep-0484>` and other subsequent related PEPs.
 """
+
 from __future__ import annotations
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing import Self
 
 # =============================================================================
 # TYPES
@@ -75,7 +75,7 @@ class Comparable(Protocol[_CT_contra]):
 
         :return: ``True`` if ``self > other``, ``False`` otherwise.
         """
-        return not(self < other or self == other)
+        return not (self < other or self == other)
 
     @abstractmethod
     def __le__(self: Self, other: _CT_contra, /) -> bool:

--- a/src/sghi/utils/__init__.py
+++ b/src/sghi/utils/__init__.py
@@ -1,6 +1,4 @@
-"""
-Common utilities used throughout SGHI projects.
-"""
+"""Common utilities used throughout SGHI projects."""
 
 from .checkers import (
     ensure_greater_or_equal,

--- a/src/sghi/utils/checkers.py
+++ b/src/sghi/utils/checkers.py
@@ -1,6 +1,5 @@
-"""
-Useful validators and predicates.
-"""
+"""Useful validators and predicates."""
+
 from collections.abc import Callable, Sized
 from typing import Any, TypeVar
 
@@ -20,12 +19,11 @@ _T = TypeVar("_T")
 
 
 def ensure_greater_or_equal(
-        value: Comparable,
-        base_value: Comparable,
-        message: str = "'value' must be greater than or equal to 'base_value'.",  # noqa: E501
+    value: Comparable,
+    base_value: Comparable,
+    message: str = "'value' must be greater than or equal to 'base_value'.",
 ) -> Comparable:
-    """
-    Check that the given value is greater that or equal to the given base
+    """Check that the given value is greater that or equal to the given base
     value.
 
     If ``value`` is less than the given ``base_value``, then a
@@ -47,9 +45,9 @@ def ensure_greater_or_equal(
 
 
 def ensure_greater_than(
-        value: Comparable,
-        base_value: Comparable,
-        message: str = "'value' must be greater than 'base_value'.",
+    value: Comparable,
+    base_value: Comparable,
+    message: str = "'value' must be greater than 'base_value'.",
 ) -> Comparable:
     """Check that the given value is greater that the given base value.
 
@@ -72,9 +70,9 @@ def ensure_greater_than(
 
 
 def ensure_instance_of(
-        value: Any,  # noqa: ANN401
-        klass: type[_T],
-        message: str | None = None,
+    value: Any,  # noqa: ANN401
+    klass: type[_T],
+    message: str | None = None,
 ) -> _T:
     """Check that the given value is an instance of the given type.
 
@@ -93,6 +91,7 @@ def ensure_instance_of(
     """
     if not isinstance(value, klass):
         from .others import type_fqn
+
         _message: str = message or (
             f"'value' is not an instance of '{type_fqn(klass)}'."
         )
@@ -101,9 +100,9 @@ def ensure_instance_of(
 
 
 def ensure_less_or_equal(
-        value: Comparable,
-        base_value: Comparable,
-        message: str = "'value' must be less than or equal to 'base_value'.",
+    value: Comparable,
+    base_value: Comparable,
+    message: str = "'value' must be less than or equal to 'base_value'.",
 ) -> Comparable:
     """Check that the given value is less than or equal the given base value.
 
@@ -126,9 +125,9 @@ def ensure_less_or_equal(
 
 
 def ensure_less_than(
-        value: Comparable,
-        base_value: Comparable,
-        message: str = "'value' must be less than 'base_value'.",
+    value: Comparable,
+    base_value: Comparable,
+    message: str = "'value' must be less than 'base_value'.",
 ) -> Comparable:
     """Check that the given value is less that the given base value.
 
@@ -151,8 +150,8 @@ def ensure_less_than(
 
 
 def ensure_not_none(
-        value: _T | None,
-        message: str = '"value" cannot be None.',
+    value: _T | None,
+    message: str = '"value" cannot be None.',
 ) -> _T:
     """Check that a given value is not ``None``.
 
@@ -173,8 +172,8 @@ def ensure_not_none(
 
 
 def ensure_not_none_nor_empty(
-        value: _ST,
-        message: str = '"value" cannot be None or empty.',
+    value: _ST,
+    message: str = '"value" cannot be None or empty.',
 ) -> _ST:
     """
     Check that a :class:`Sized` value is not ``None`` or empty (has a size of
@@ -197,12 +196,11 @@ def ensure_not_none_nor_empty(
 
 
 def ensure_optional_instance_of(
-        value: Any,  # noqa: ANN401
-        klass: type[_T],
-        message: str | None = None,
+    value: Any,  # noqa: ANN401
+    klass: type[_T],
+    message: str | None = None,
 ) -> _T | None:
-    """
-    Check that the given value is ``None`` or an instance of the given type.
+    """Check that the given value is ``None`` or an instance of the given type.
 
     If ``value`` is not ``None`` or an instance of ``klass``, then a
     :exc:`TypeError` is raised; else ``value`` is returned as is.
@@ -219,6 +217,7 @@ def ensure_optional_instance_of(
     """
     if not isinstance(value, type(None) | klass):
         from .others import type_fqn
+
         _message: str = message or (
             f"'value' is not an instance of '{type_fqn(klass)}' or None."
         )
@@ -227,9 +226,9 @@ def ensure_optional_instance_of(
 
 
 def ensure_predicate(
-        test: bool,
-        message: str = "Invalid value. Predicate evaluation failed.",
-        exc_factory: Callable[[str], BaseException] = ValueError,
+    test: bool,
+    message: str = "Invalid value. Predicate evaluation failed.",
+    exc_factory: Callable[[str], BaseException] = ValueError,
 ) -> None:
     """Check that a predicate evaluation passes.
 

--- a/src/sghi/utils/module_loading.py
+++ b/src/sghi/utils/module_loading.py
@@ -1,6 +1,5 @@
-"""
-Utilities to load modules, types, and objects from dotted path strings.
-"""
+"""Utilities to load modules, types, and objects from dotted path strings."""
+
 import inspect
 from typing import Any, Final, TypeVar, cast
 
@@ -31,8 +30,7 @@ _UNKNOWN_STR: Final[str] = "UNKNOWN"
 
 
 def import_string(dotted_path: str) -> Any:  # noqa: ANN401
-    """
-    Import a dotted module path and return the Python object designated by
+    """Import a dotted module path and return the Python object designated by
     the last name in the path.
 
     The `dotted path` can refer to any "importable" Python object
@@ -50,7 +48,6 @@ def import_string(dotted_path: str) -> Any:  # noqa: ANN401
     :raises ImportError: If the import fails for some reason.
     :raises ValueError: If the given dotted path is ``None`` or empty.
     """
-
     entry_point = EntryPoint(
         name=_UNKNOWN_STR,
         group=_UNKNOWN_STR,
@@ -92,8 +89,8 @@ def import_string_as_klass(
     _module = import_string(dotted_path)
     if not inspect.isclass(_module) or not issubclass(_module, target_klass):
         err_msg: str = (
-            "Invalid value, '{}' does not refer to a valid type or to a "
-            "subtype of '{}'.".format(dotted_path, type_fqn(target_klass))
+            f"Invalid value, '{dotted_path}' does not refer to a valid type "
+            f"or to a subtype of '{type_fqn(target_klass)}'."
         )
         raise TypeError(err_msg)
 

--- a/src/sghi/utils/others.py
+++ b/src/sghi/utils/others.py
@@ -1,4 +1,5 @@
 """Other useful utilities."""
+
 from collections.abc import Callable
 from concurrent.futures import Future
 from typing import Any

--- a/test/sghi/app_tests.py
+++ b/test/sghi/app_tests.py
@@ -8,23 +8,18 @@ def test_conf_attribute() -> None:
     """
     :attr:`sghi.app.conf` should not be ``None`` and of type :class:`Config`.
     """
-
     assert isinstance(sghi.app.conf, Config)
 
 
 def test_dispatcher_attribute() -> None:
-    """
-    :attr:`sghi.app.dispatcher` should not be ``None`` and of type
+    """:attr:`sghi.app.dispatcher` should not be ``None`` and of type
     :class:`Dispatcher`.
     """
-
     assert isinstance(sghi.app.dispatcher, Dispatcher)
 
 
 def test_registry_attribute() -> None:
-    """
-    :attr:`sghi.app.registry` should not be ``None`` and of type
+    """:attr:`sghi.app.registry` should not be ``None`` and of type
     :class:`Registry`.
     """
-
     assert isinstance(sghi.app.registry, Registry)

--- a/test/sghi/config_tests.py
+++ b/test/sghi/config_tests.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 
 @register
 class DBPortInitializer(SettingInitializer):
-
     __slots__ = ()
 
     @property
@@ -59,7 +58,6 @@ class DBPortInitializer(SettingInitializer):
 
 
 class DBPasswordInitializer(SettingInitializer):
-
     __slots__ = ()
 
     @property
@@ -87,7 +85,6 @@ def test_get_registered_initializer_factories_return_value() -> None:
     """:func:`get_registered_initializer_factories` should return all
     initializer factories decorated using the :func:`register` decorator.
     """
-
     assert len(get_registered_initializer_factories()) == 1
     for init_factory in get_registered_initializer_factories():
         assert isinstance(init_factory(), SettingInitializer)
@@ -110,7 +107,6 @@ class TestConfig(TestCase):
         :meth:`Config.of` should return a ``Config`` instance created from the
         given settings and setting initializers.
         """
-
         config1: Config = Config.of(
             settings=self._settings,
             setting_initializers=self._setting_initializers,
@@ -157,11 +153,9 @@ class TestConfig(TestCase):
         assert exc_info.value.setting == "DB_PASSWORD"
 
     def test_of_awaiting_setup_factory_method_return_value(self) -> None:
-        """
-        :meth:`Config.of_awaiting_setup` should return a ``Config`` instance
+        """:meth:`Config.of_awaiting_setup` should return a ``Config`` instance
         that raises ``NotSetupError`` on any attempted access to its settings.
         """
-
         config1: Config = Config.of_awaiting_setup()
         config2: Config = Config.of_awaiting_setup(err_msg="Setup required!!!")
 
@@ -192,7 +186,6 @@ class TestConfig(TestCase):
         that represents an application that is not set up when a source
         ``Config`` is not provided.
         """
-
         config1: Config = Config.of_proxy()
         config2: Config = Config.of_proxy(not_setup_err_msg="Setup required!")
         config3: Config = Config.of_proxy(
@@ -211,13 +204,13 @@ class TestConfig(TestCase):
         assert "DB_PORT" in config3
         assert config3.DB_PORT == 5432
 
-    def test_of_proxy_err_msg_ignored_when_source_config_is_not_none(self) -> None:  # noqa: E501
-        """
-        :meth:`Config.of_proxy` should ignore the ``not_setup_err_msg``
+    def test_of_proxy_err_msg_ignored_when_source_config_is_not_none(
+        self,
+    ) -> None:
+        """:meth:`Config.of_proxy` should ignore the ``not_setup_err_msg``
         parameter if the corresponding ``source_config`` parameter is not
         ``None``.
         """
-
         config: Config = Config.of_proxy(
             source_config=Config.of_awaiting_setup(err_msg="Not yet!!"),
             not_setup_err_msg="Setup required!",
@@ -241,20 +234,16 @@ class TestConfigProxy(TestCase):
         self._instance: ConfigProxy = ConfigProxy(self._source_config)
 
     def test_init_fails_on_none_input_value(self) -> None:
-        """
-        :meth:`ConfigProxy.__init__` should raise a :exc:`ValueError` when
+        """:meth:`ConfigProxy.__init__` should raise a :exc:`ValueError` when
         given a ``None`` ``source_config``.
         """
-
         with pytest.raises(ValueError, match="config' MUST not be None"):
             ConfigProxy(source_config=None)  # type: ignore
 
     def test_dunder_contains_return_value(self) -> None:
-        """
-        :meth:`ConfigProxy.__contains__` should return the same value as its
+        """:meth:`ConfigProxy.__contains__` should return the same value as its
         wrapped ``Config`` value.
         """
-
         assert "DB_PORT" in self._source_config
         assert "DB_PORT" in self._instance
         assert "DB_PASSWORD" in self._source_config
@@ -263,11 +252,9 @@ class TestConfigProxy(TestCase):
         assert "DB_NAME" not in self._instance
 
     def test_dunder_getattr_return_value(self) -> None:
-        """
-        :meth:`ConfigProxy.__getattr__` should return the same value as its
+        """:meth:`ConfigProxy.__getattr__` should return the same value as its
         wrapped ``Config`` value.
         """
-
         assert self._source_config.DB_PORT == 5432
         assert self._instance.DB_PORT == 5432
         assert self._source_config.DB_PASSWORD == "s3c3r3PA55word!"  # noqa: S105
@@ -279,31 +266,30 @@ class TestConfigProxy(TestCase):
         if access to non-existing setting on the wrapped ``Config`` value is
         made.
         """
-
         with pytest.raises(NoSuchSettingError) as exc_info:
             self._instance.DB_NAME  # noqa B018
 
         assert exc_info.value.setting == "DB_NAME"
 
     def test_get_method_return_value(self) -> None:
-        """
-        :meth:`ConfigProxy.get` should return the same value as its wrapped
+        """:meth:`ConfigProxy.get` should return the same value as its wrapped
         ``Config`` value.
         """
-
         source: Config = self._source_config
         instan: Config = self._instance
 
         assert source.get("DB_PORT") == instan.get("DB_PORT") == 5432
-        assert source.get("DB_PASSWORD") == instan.get("DB_PASSWORD") == "s3c3r3PA55word!"  # noqa: E501
+        assert (
+            source.get("DB_PASSWORD")
+            == instan.get("DB_PASSWORD")
+            == "s3c3r3PA55word!"
+        )
         assert source.get("DB_NAME") is instan.get("DB_NAME") is None
 
     def test_set_source_method_side_effects(self) -> None:
-        """
-        :meth:`Config.set_source` should swap the wrapped source ``Config``
+        """:meth:`Config.set_source` should swap the wrapped source ``Config``
         instance to the new provided value.
         """
-
         self._instance.set_source(
             Config.of({}, skip_registered_initializers=True),
         )
@@ -317,25 +303,20 @@ class TestConfigProxy(TestCase):
         :meth:`Config.set_source` should raise :exc:``ValueError`` when given
         a ``None`` source ``Config`` instance as input.
         """
-
         with pytest.raises(ValueError, match="config' MUST not be None."):
             self._instance.set_source(source_config=None)  # type: ignore
 
 
 class TestSettingInitializer(TestCase):
-    """
-    Tests for the :SettingInitializer: interface default implementations.
-    """
+    """Tests for the :SettingInitializer: interface default implementations."""
 
     def test_has_secrets_return_value(self) -> None:
-        """
-        The default implementation of :attr:`SettingInitializer.has_secrets`
+        """The default implementation of :attr:`SettingInitializer.has_secrets`
         should evaluate to ``False``.
         """
 
         class SomeInitializer(SettingInitializer):
-            """
-            A :class:`SettingInitializer` implementation that relies on the
+            """A :class:`SettingInitializer` implementation that relies on the
             default :attr:`SettingInitializer.has_secrets` implementation.
             """
 

--- a/test/sghi/dispatch_tests.py
+++ b/test/sghi/dispatch_tests.py
@@ -29,7 +29,6 @@ class CounterReset(Signal):
 
 
 class Counter:
-
     __slots__ = ("_current", "_max_count", "_dispatcher")
 
     def __init__(self, max_count: int) -> None:
@@ -72,27 +71,21 @@ class Counter:
 
 
 class TestDispatcher(TestCase):
-    """
-    Tests for the :class:`Dispatcher` interface default implementations.
-    """
+    """Tests for the :class:`Dispatcher` interface default implementations."""
 
     def test_of_factory_method_return_value(self) -> None:
         """:meth:`Dispatcher.of` should return a ``Dispatch`` instance."""
-
         assert isinstance(Dispatcher.of(), Dispatcher)
 
     def test_of_proxy_factory_method_return_value(self) -> None:
-        """
-        :meth:`Dispatcher.of_proxy` should return a ``DispatcherProxy``
+        """:meth:`Dispatcher.of_proxy` should return a ``DispatcherProxy``
         instance.
         """
-
         assert isinstance(Dispatcher.of_proxy(), DispatcherProxy)
 
 
 class TestDispatcherOf(TestCase):
-    """
-    Tests for the :class:`Dispatcher` implementation returned by the
+    """Tests for the :class:`Dispatcher` implementation returned by the
     :meth:`Dispatcher.of` factory method.
     """
 
@@ -103,8 +96,7 @@ class TestDispatcherOf(TestCase):
         self._counter: Counter = Counter(self._counter_max_value)
 
     def test_connect_fails_on_non_type_signal_type_as_input(self) -> None:
-        """
-        :meth:`Dispatcher.connect` should raise a :exc:`TypeError` when
+        """:meth:`Dispatcher.connect` should raise a :exc:`TypeError` when
         given a `signal_type` parameter that is not a type.
         """
         with pytest.raises(TypeError, match="MUST be a type") as exc_info:
@@ -116,8 +108,7 @@ class TestDispatcherOf(TestCase):
         assert exc_info.value.args[0] == "'signal_type' MUST be a type."
 
     def test_connect_fails_on_signal_type_not_signal_subclass(self) -> None:
-        """
-        :meth:`Dispatcher.connect` should raise a :exc:`TypeError` when
+        """:meth:`Dispatcher.connect` should raise a :exc:`TypeError` when
         given a `signal_type` parameter that is not a subclass of
         :class:`Signal`.
         """
@@ -128,7 +119,7 @@ class TestDispatcherOf(TestCase):
             )
 
         assert exc_info.value.args[0] == (
-                f"'signal_type' MUST be a subclass of '{type_fqn(Signal)}'."
+            f"'signal_type' MUST be a subclass of '{type_fqn(Signal)}'."
         )
 
     def test_connect_fails_on_none_receiver_as_input_value(self) -> None:
@@ -140,15 +131,14 @@ class TestDispatcherOf(TestCase):
             self._instance.connect(CounterAdvanced, None)  # type: ignore
 
     def test_connect_side_effects_when_weak_is_set_to_false(self) -> None:
-        """
-        :meth:`Dispatcher.connect` should add a receiver and retain it even
+        """:meth:`Dispatcher.connect` should add a receiver and retain it even
         when it would normally be garbage collected when the ``weak``
         parameter is set to ``False``.
         """
         output: list[int] = []
 
-        def on_counter_advanced(signa: CounterAdvanced) -> None:
-            output.append(signa.current_value)
+        def on_counter_advanced(signal: CounterAdvanced) -> None:
+            output.append(signal.current_value)
 
         class OnCounterAdvance:
             def execute(self, signal: CounterAdvanced) -> None:
@@ -175,15 +165,14 @@ class TestDispatcherOf(TestCase):
         assert output[1] == 1
 
     def test_connect_side_effects_when_weak_is_set_to_true(self) -> None:
-        """
-        :meth:`Dispatcher.connect` should add a receiver but automatically
+        """:meth:`Dispatcher.connect` should add a receiver but automatically
         remove it after garbage collection when the ``weak`` parameter is set
         to ``True``.
         """
         output: list[int] = []
 
-        def on_counter_advanced(signa: CounterAdvanced) -> None:
-            output.append(signa.current_value)
+        def on_counter_advanced(signal: CounterAdvanced) -> None:
+            output.append(signal.current_value)
 
         class OnCounterAdvance:
             def execute(self, signal: CounterAdvanced) -> None:
@@ -208,8 +197,7 @@ class TestDispatcherOf(TestCase):
         assert len(output) == 0
 
     def test_disconnect_fails_on_non_type_signal_type_as_input(self) -> None:
-        """
-        :meth:`Dispatcher.disconnect` should raise a :exc:`TypeError` when
+        """:meth:`Dispatcher.disconnect` should raise a :exc:`TypeError` when
         given a `signal_type` parameter that is not a type.
         """
         with pytest.raises(TypeError, match="MUST be a type") as exc_info:
@@ -221,8 +209,7 @@ class TestDispatcherOf(TestCase):
         assert exc_info.value.args[0] == "'signal_type' MUST be a type."
 
     def test_disconnect_fails_on_signal_type_not_signal_subclass(self) -> None:
-        """
-        :meth:`Dispatcher.disconnect` should raise a :exc:`TypeError` when
+        """:meth:`Dispatcher.disconnect` should raise a :exc:`TypeError` when
         given a `signal_type` parameter that is not a subclass of
         :class:`Signal`.
         """
@@ -237,8 +224,7 @@ class TestDispatcherOf(TestCase):
         )
 
     def test_disconnect_fails_on_none_receiver_as_input_value(self) -> None:
-        """
-        :meth:`Dispatcher.disconnect` should raise a :exc:`ValueError` when
+        """:meth:`Dispatcher.disconnect` should raise a :exc:`ValueError` when
         given a ``None`` value on the ``receiver`` parameter.
         """
         with pytest.raises(ValueError, match="MUST not be None"):
@@ -253,12 +239,12 @@ class TestDispatcherOf(TestCase):
         output: list[int] = []
 
         @connect(CounterAdvanced, dispatcher=counter.dispatcher, weak=False)
-        def on_counter_advanced1(signa: CounterAdvanced) -> None:  # type: ignore
-            output.append(signa.current_value)
+        def on_counter_advanced1(signal: CounterAdvanced) -> None:  # type: ignore
+            output.append(signal.current_value)
 
         @connect(CounterAdvanced, dispatcher=counter.dispatcher, weak=False)
-        def on_counter_advanced2(signa: CounterAdvanced) -> None:
-            output.append(signa.current_value)
+        def on_counter_advanced2(signal: CounterAdvanced) -> None:
+            output.append(signal.current_value)
 
         counter.advance_counter()
         counter.dispatcher.disconnect(CounterAdvanced, on_counter_advanced2)
@@ -278,12 +264,12 @@ class TestDispatcherOf(TestCase):
         output: list[int] = []
 
         @connect(CounterAdvanced, dispatcher=counter.dispatcher, weak=True)
-        def on_counter_advanced1(signa: CounterAdvanced) -> None:
-            output.append(signa.current_value)
+        def on_counter_advanced1(signal: CounterAdvanced) -> None:
+            output.append(signal.current_value)
 
         @connect(CounterAdvanced, dispatcher=counter.dispatcher, weak=True)
-        def on_counter_advanced2(signa: CounterAdvanced) -> None:  # type: ignore
-            output.append(signa.current_value)
+        def on_counter_advanced2(signal: CounterAdvanced) -> None:  # type: ignore
+            output.append(signal.current_value)
 
         counter.advance_counter()
         counter.dispatcher.disconnect(CounterAdvanced, on_counter_advanced1)
@@ -295,16 +281,15 @@ class TestDispatcherOf(TestCase):
         assert output[2] == 2
 
     def test_send_fails_when_signal_is_not_a_signal(self) -> None:
-        """
-        :method:`Dispatcher.send` should raise a :exc:`ValueError` when the
+        """:method:`Dispatcher.send` should raise a :exc:`ValueError` when the
         ``signal`` parameter is not an instance of :class:`Signal`.
         """
 
     def test_send_side_effects_when_robust_is_set_to_false(self) -> None:
-        """
-        :meth:`Dispatcher.send` should propagate any errors raised by
+        """:meth:`Dispatcher.send` should propagate any errors raised by
         receivers.
         """
+
         @connect(CounterReset, dispatcher=self._instance, weak=False)
         def on_counter_reset(signal: CounterReset) -> None:  # type: ignore
             raise ZeroDivisionError
@@ -313,8 +298,7 @@ class TestDispatcherOf(TestCase):
             self._instance.send(CounterReset(0), robust=False)
 
     def test_send_side_effects_when_robust_is_set_to_true(self) -> None:
-        """
-        :meth:`Dispatcher.send` should silently discard any errors raised by
+        """:meth:`Dispatcher.send` should silently discard any errors raised by
         receivers.
         """
         output: list[int] = []
@@ -336,8 +320,7 @@ class TestDispatcherOf(TestCase):
         assert output[0] == 0
 
     @staticmethod
-    def on_counter_reset(signal: CounterReset) -> None:
-        ...
+    def on_counter_reset(signal: CounterReset) -> None: ...
 
 
 class TestDispatcherProxy(TestCase):
@@ -350,7 +333,9 @@ class TestDispatcherProxy(TestCase):
             self._source_dispatcher,
         )
 
-    def test_init_fails_when_source_dispatcher_is_not_a_dispatcher(self) -> None:  # noqa: E501
+    def test_init_fails_when_source_dispatcher_is_not_a_dispatcher(
+        self,
+    ) -> None:
         """
         :meth:`DispatcherProxy.__init__` should raise a :exc:`TypeError` when
         the ``source_dispatcher`` parameter given is not an instance of
@@ -369,8 +354,8 @@ class TestDispatcherProxy(TestCase):
         """
         output: list[int] = []
 
-        def on_counter_advanced(signa: CounterAdvanced) -> None:
-            output.append(signa.current_value)
+        def on_counter_advanced(signal: CounterAdvanced) -> None:
+            output.append(signal.current_value)
 
         class OnCounterAdvance:
             def execute(self, signal: CounterAdvanced) -> None:
@@ -406,12 +391,12 @@ class TestDispatcherProxy(TestCase):
         output: list[int] = []
 
         @connect(CounterAdvanced, dispatcher=self._instance, weak=False)
-        def on_counter_advanced1(signa: CounterAdvanced) -> None:
-            output.append(signa.current_value)
+        def on_counter_advanced1(signal: CounterAdvanced) -> None:
+            output.append(signal.current_value)
 
         @connect(CounterAdvanced, dispatcher=self._instance, weak=True)
-        def on_counter_advanced2(signa: CounterAdvanced) -> None:
-            output.append(signa.current_value)
+        def on_counter_advanced2(signal: CounterAdvanced) -> None:
+            output.append(signal.current_value)
 
         self._instance.send(CounterAdvanced(current_value=1, advanced_by=1))
 
@@ -425,12 +410,13 @@ class TestDispatcherProxy(TestCase):
         assert output[0] == 1
         assert output[1] == 1
 
-    def test_set_source_fails_when_source_dispatch_is_not_a_dispatcher(self) -> None:  # noqa: E501
+    def test_set_source_fails_when_source_dispatch_is_not_a_dispatcher(
+        self,
+    ) -> None:
         """
         :meth:`DispatcherProxy.set_source` should raise a :exc:`TypeError` when
         the ``source_dispatcher`` parameter given is not an instance of
         :class:`Dispatcher`.
         """
-
         with pytest.raises(TypeError, match="is not an instance of"):
             self._instance.set_source(source_dispatcher=None)  # type: ignore

--- a/test/sghi/disposable_tests.py
+++ b/test/sghi/disposable_tests.py
@@ -10,13 +10,11 @@ from sghi.disposable import Disposable, ResourceDisposedError, not_disposed
 
 
 class _SomeItemDisposedError(ResourceDisposedError):
-
     def __init__(self, msg: str = "SomeDisposableItem is already disposed"):
         super().__init__(message=msg)
 
 
 class _SomeDisposableItem(Disposable):
-
     __slots__ = ("_is_disposed",)
 
     def __init__(self) -> None:
@@ -31,8 +29,7 @@ class _SomeDisposableItem(Disposable):
         self._is_disposed = True
 
     @not_disposed
-    def use_resources1(self) -> None:
-        ...
+    def use_resources1(self) -> None: ...
 
     @not_disposed(exc_factory=_SomeItemDisposedError)
     def use_resources2(self) -> str:
@@ -48,12 +45,10 @@ class TestDisposable(TestCase):
     """Tests for the :class:`Disposable` mixin."""
 
     def test_object_is_disposed_on_context_manager_exit(self) -> None:
-        """
-        As per the default implementation of the :class:`Disposable` mixin ,
+        """As per the default implementation of the :class:`Disposable` mixin ,
         a ``Disposable`` object's ``dispose()`` method should be invoked when
         exiting a context manager.
         """
-
         with _SomeDisposableItem() as disposable:
             # Resource should not be disposed at this time
             assert not disposable.is_disposed
@@ -65,8 +60,7 @@ class TestNotDisposedDecorator(TestCase):
     """Tests for the :func:`not_disposed` decorator."""
 
     def test_decorated_methods_return_normally_when_not_disposed(self) -> None:
-        """
-        Methods decorated using the ``not_disposed`` decorator should return
+        """Methods decorated using the ``not_disposed`` decorator should return
         normally, i.e., without raising :exc:`ResourceDisposedError` if their
         bound ``Disposable`` object is yet to be disposed.
         """
@@ -82,14 +76,14 @@ class TestNotDisposedDecorator(TestCase):
 
         assert disposable.is_disposed
 
-    def test_decorated_methods_raise_expected_errors_when_disposed(self) -> None:  # noqa: E501
-        """
-        Methods decorated using the ``not_disposed`` decorator should raise
+    def test_decorated_methods_raise_expected_errors_when_disposed(
+        self,
+    ) -> None:
+        """Methods decorated using the ``not_disposed`` decorator should raise
         :exc:`ResourceDisposedError` or it's derivatives (depending on whether
         the ``exc_factory`` is provided) when invoked after their bound
         ``Disposable`` object is disposed.
         """
-
         disposable: _SomeDisposableItem = _SomeDisposableItem()
         disposable.dispose()
 
@@ -103,4 +97,6 @@ class TestNotDisposedDecorator(TestCase):
         assert exc_info1.type is ResourceDisposedError
         assert exc_info1.value.message == "Resource already disposed."
         assert exc_info2.type is _SomeItemDisposedError
-        assert exc_info2.value.message == "SomeDisposableItem is already disposed"  # noqa: E501
+        assert (
+            exc_info2.value.message == "SomeDisposableItem is already disposed"
+        )

--- a/test/sghi/exceptions_tests.py
+++ b/test/sghi/exceptions_tests.py
@@ -8,7 +8,6 @@ class TestSGHIError(TestCase):
 
     def test_message_prop_return_value(self) -> None:
         """Ensure the ``message`` property returns the expected value."""
-
         error1 = SGHIError(message="Fatal error.")
         error2 = SGHIError()
 
@@ -17,7 +16,6 @@ class TestSGHIError(TestCase):
 
     def test_str_representation(self) -> None:
         """Ensure the string representation of an ``SGHIError`` is correct."""
-
         error1 = SGHIError(message="Fatal error :(")
         error2 = SGHIError()
 

--- a/test/sghi/registry_tests.py
+++ b/test/sghi/registry_tests.py
@@ -19,14 +19,12 @@ class TestRegistry(TestCase):
 
     def test_of_factory_method_return_value(self) -> None:
         """:meth:`Registry.of` should return a ``Registry`` instance."""
-
         assert isinstance(Registry.of(), Registry)
 
     def test_of_proxy_factory_method_return_value(self) -> None:
         """
         :meth:`Registry.of_proxy` should return a ``RegistryProxy`` instance.
         """
-
         assert isinstance(RegistryProxy.of_proxy(), RegistryProxy)
 
 
@@ -47,7 +45,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.__contain__` should return ``True`` if an item with the
         specified key exists in the registry or ``False`` otherwise.
         """
-
         assert "ITEM_KEY_1" in self._instance
         assert "ITEM_KEY_2" in self._instance
         assert "ITEM_KEY_3" not in self._instance
@@ -57,7 +54,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.__delitem__` should remove the given item from the
         registry if it is already present.
         """
-
         output: set[str] = set()
 
         @connect(RegistryItemRemoved, dispatcher=self._instance.dispatcher)
@@ -78,7 +74,6 @@ class TestRegistryOf(TestCase):
         :exc:`NoSuchRegistryItemError` when given an item that is non-existent
         in the registry.
         """
-
         with pytest.raises(NoSuchRegistryItemError) as exc_info:
             del self._instance["ITEM_KEY_3"]
 
@@ -89,7 +84,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.__delitem__` should raise a :exc:`ValueError` when
         given a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -102,7 +96,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.__getitem__` should return the value associated with
         the given item from the registry if it is already present.
         """
-
         assert self._instance["ITEM_KEY_1"] == "ITEM_VALUE_1"
         assert self._instance["ITEM_KEY_2"] == "ITEM_VALUE_2"
 
@@ -112,7 +105,6 @@ class TestRegistryOf(TestCase):
         :exc:`NoSuchRegistryItemError` when given a key of a non-existent item
         in the registry.
         """
-
         with pytest.raises(NoSuchRegistryItemError) as exc_info:
             value = self._instance["ITEM_KEY_3"]  # pyright: ignore  # noqa: F841
 
@@ -123,7 +115,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.__getitem__` should raise a :exc:`ValueError` when
         given a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -136,7 +127,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.__setitem__` should add an item in the registry or
         update the value of an existing item.
         """
-
         output: dict[str, str] = {}
 
         @connect(RegistryItemSet, dispatcher=self._instance.dispatcher)
@@ -158,7 +148,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.__setitem__` should raise a :exc:`ValueError` when
         given a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -172,7 +161,6 @@ class TestRegistryOf(TestCase):
         item from the registry if it is already present. It should return
         ``None`` of the given default if the item is not in the registry.
         """
-
         assert self._instance.get("ITEM_KEY_1") == "ITEM_VALUE_1"
         assert self._instance.get("ITEM_KEY_2") == "ITEM_VALUE_2"
         assert self._instance.get("ITEM_KEY_3") is None
@@ -183,7 +171,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.get` should raise a :exc:`ValueError` when given a
         ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -196,7 +183,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.pop` should raise a :exc:`ValueError` when given a
         ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -210,7 +196,6 @@ class TestRegistryOf(TestCase):
         registry if it is already present. If not, it should return ``None`` or
         the given default.
         """
-
         output: set[str] = set()
 
         @connect(RegistryItemRemoved, dispatcher=self._instance.dispatcher)
@@ -233,7 +218,6 @@ class TestRegistryOf(TestCase):
         :meth:`Registry.setdefault` should raise a :exc:`ValueError` when given
         a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -247,7 +231,6 @@ class TestRegistryOf(TestCase):
         the specified key from the registry, or set it if the key does not
         exist.
         """
-
         output: dict[str, str] = {}
 
         @connect(RegistryItemSet, dispatcher=self._instance.dispatcher)
@@ -266,7 +249,6 @@ class TestRegistryOf(TestCase):
 
 
 class TestRegistryProxy(TestCase):
-
     def setUp(self) -> None:
         super().setUp()
         self._source_registry: Registry = Registry.of()
@@ -281,7 +263,7 @@ class TestRegistryProxy(TestCase):
         :class:`Registry`.
         """
         with pytest.raises(TypeError, match="is not an instance of"):
-            RegistryProxy(source_registry=None)   # type: ignore
+            RegistryProxy(source_registry=None)  # type: ignore
 
         with pytest.raises(TypeError, match="is not an instance of"):
             RegistryProxy(source_registry={})  # type: ignore
@@ -291,7 +273,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.__contain__` should return ``True`` if an item
         with the specified key exists in the registry or ``False`` otherwise.
         """
-
         assert "ITEM_KEY_1" in self._instance
         assert "ITEM_KEY_2" in self._instance
         assert "ITEM_KEY_3" not in self._instance
@@ -301,7 +282,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.__delitem__` should remove the given item from the
         registry if it is already present.
         """
-
         output: set[str] = set()
 
         @connect(RegistryItemRemoved, dispatcher=self._instance.dispatcher)
@@ -322,7 +302,6 @@ class TestRegistryProxy(TestCase):
         :exc:`NoSuchRegistryItemError` when given an item that is non-existent
         in the registry.
         """
-
         with pytest.raises(NoSuchRegistryItemError) as exc_info:
             del self._instance["ITEM_KEY_3"]
 
@@ -333,7 +312,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.__delitem__` should raise a :exc:`ValueError` when
         given a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -346,7 +324,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.__getitem__` should return the value associated
         with the given item from the registry if it is already present.
         """
-
         assert self._instance["ITEM_KEY_1"] == "ITEM_VALUE_1"
         assert self._instance["ITEM_KEY_2"] == "ITEM_VALUE_2"
 
@@ -356,7 +333,6 @@ class TestRegistryProxy(TestCase):
         :exc:`NoSuchRegistryItemError` when given a key of a non-existent item
         in the registry.
         """
-
         with pytest.raises(NoSuchRegistryItemError) as exc_info:
             value = self._instance["ITEM_KEY_3"]  # pyright: ignore  # noqa: F841
 
@@ -367,7 +343,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.__getitem__` should raise a :exc:`ValueError` when
         given a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -380,7 +355,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.__setitem__` should add an item in the registry or
         update the value of an existing item.
         """
-
         output: dict[str, str] = {}
 
         @connect(RegistryItemSet, dispatcher=self._instance.dispatcher)
@@ -402,7 +376,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.__setitem__` should raise a :exc:`ValueError` when
         given a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -416,7 +389,6 @@ class TestRegistryProxy(TestCase):
         given item from the registry if it is already present. It should return
         ``None`` of the given default if the item is not in the registry.
         """
-
         assert self._instance.get("ITEM_KEY_1") == "ITEM_VALUE_1"
         assert self._instance.get("ITEM_KEY_2") == "ITEM_VALUE_2"
         assert self._instance.get("ITEM_KEY_3") is None
@@ -427,7 +399,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.get` should raise a :exc:`ValueError` when given
         a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -440,7 +411,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.pop` should raise a :exc:`ValueError` when given a
         ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -454,7 +424,6 @@ class TestRegistryProxy(TestCase):
         the registry if it is already present. If not, it should return
         ``None`` or the given default.
         """
-
         output: set[str] = set()
 
         @connect(RegistryItemRemoved, dispatcher=self._instance.dispatcher)
@@ -472,13 +441,14 @@ class TestRegistryProxy(TestCase):
         assert "ITEM_KEY_1" not in self._instance
         assert "ITEM_KEY_2" not in self._instance
 
-    def test_set_source_fails_when_source_register_is_not_a_registry(self) -> None:  # noqa: E501
+    def test_set_source_fails_when_source_register_is_not_a_registry(
+        self,
+    ) -> None:
         """
         :meth:`RegistryProxy.set_source` should raise a :exc:`TypeError` when
         the ``source_registry`` parameter given is not an instance of
         :class:`Registry`.
         """
-
         with pytest.raises(TypeError, match="is not an instance of"):
             self._instance.set_source(source_registry=None)  # type: ignore
 
@@ -487,7 +457,6 @@ class TestRegistryProxy(TestCase):
         :meth:`RegistryProxy.setdefault` should raise a :exc:`ValueError` when
         given a ``None`` item key.
         """
-
         item_key: str = None  # type: ignore
 
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
@@ -501,7 +470,6 @@ class TestRegistryProxy(TestCase):
         with the specified key from the registry, or set it if the key does not
         exist.
         """
-
         output: dict[str, str] = {}
 
         @connect(RegistryItemSet, dispatcher=self._instance.dispatcher)

--- a/test/sghi/task_tests.py
+++ b/test/sghi/task_tests.py
@@ -26,12 +26,10 @@ class TestConsume(TestCase):
     """Tests for the :class:`consume` ``Task``."""
 
     def test_and_then_method_returns_expected_value(self) -> None:
-        """
-        :meth:`consume.and_then` method should return a new instance of
+        """:meth:`consume.and_then` method should return a new instance of
         :class:`consume` that composes both the action of the current
         ``consume`` instance and the new action.
         """
-
         collection1: list[int] = []
         collection2: set[int] = set()
 
@@ -84,12 +82,13 @@ class TestConsume(TestCase):
         assert results[2] == value
         assert value == 30  # value should not have changed
 
-    def test_different_and_then_method_invocation_styles_return_same_value(self) -> None:  # noqa: E501
+    def test_different_and_then_method_invocation_styles_return_same_value(
+        self,
+    ) -> None:
         """
         :meth:`consume.execute` should return the same value regardless of how
         it was invoked.
         """
-
         collection1: list[int] = []
         collection2: set[int] = set()
         collection3: list[int] = []
@@ -117,12 +116,13 @@ class TestConsume(TestCase):
         assert len(collection1) == len(collection2) == 3
         assert len(collection3) == len(collection4) == 3
 
-    def test_different_execute_invocation_styles_return_same_value(self) -> None:  # noqa: E501
+    def test_different_execute_invocation_styles_return_same_value(
+        self,
+    ) -> None:
         """
         :meth:`consume.execute` should return the same value regardless of how
         it was invoked.
         """
-
         results1: list[int] = []
         collector1: consume[int] = consume(accept=results1.append)
         results2: list[int] = []
@@ -160,7 +160,6 @@ class TestChain(TestCase):
         :meth:`chain.execute` method should raise a :exc:`ValueError` when
         invoked with a ``None`` argument.
         """
-
         with pytest.raises(ValueError, match="MUST not be None.") as exc_info:
             self._chain_of_10(None)  # type: ignore
 
@@ -171,31 +170,31 @@ class TestChain(TestCase):
         :meth:`chain.execute` method should return a new :class:`chain`
         instance with the new computed value.
         """
-
         instance: chain[int]
-        instance = self._chain_of_10\
-            .execute(self._multiply_by_2)\
-            .execute(self._add_30)
+        instance = self._chain_of_10.execute(self._multiply_by_2).execute(
+            self._add_30
+        )
 
         assert isinstance(self._chain_of_10.execute(self._add_30), chain)
         assert self._chain_of_10.execute(self._multiply_by_2).value == 20
         assert self._chain_of_10.execute(self._add_30).value == 40
         assert instance.value == 50
 
-    def test_different_execute_invocation_styles_return_same_value(self) -> None:  # noqa: E501
+    def test_different_execute_invocation_styles_return_same_value(
+        self,
+    ) -> None:
         """
         :meth:`chain.execute` should return the same value regardless of how
         it was invoked.
         """
-
         instance1: chain[int]
         instance2: chain[int]
         instance3: chain[int]
 
         # Style 1, explicit invocation
-        instance1 = self._chain_of_10\
-            .execute(self._multiply_by_2)\
-            .execute(self._add_30)
+        instance1 = self._chain_of_10.execute(self._multiply_by_2).execute(
+            self._add_30
+        )
         # Style 2, invoke as callable
         instance2 = self._chain_of_10(self._multiply_by_2)(self._add_30)
         # Style 3, using the plus operator
@@ -208,7 +207,6 @@ class TestChain(TestCase):
         :attr:`chain.value` should return the wrapped value of the current
         chain instance.
         """
-
         assert self._chain_of_10.value == 10
         assert self._chain_of_10(self._multiply_by_2).value == 20
         assert self._chain_of_10(self._add_30).value == 40
@@ -220,20 +218,20 @@ class TestConcurrentExecutor(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self._longer_io_tasks: Sequence[Task[float, float]] = tuple(
-            Task.of_callable(self._do_longer_io_bound_task)
-            for _ in range(3)
+            Task.of_callable(self._do_longer_io_bound_task) for _ in range(3)
         )
         self._short_io_tasks: Sequence[Task[float, float]] = tuple(
-            Task.of_callable(self._do_io_bound_task)
-            for _ in range(5)
+            Task.of_callable(self._do_io_bound_task) for _ in range(5)
         )
         self._blocking_executor: ConcurrentExecutor[float, float]
         self._blocking_executor = ConcurrentExecutor(
-            *self._longer_io_tasks, *self._short_io_tasks,
+            *self._longer_io_tasks,
+            *self._short_io_tasks,
         )
         self._non_blocking_executor: ConcurrentExecutor[float, float]
         self._non_blocking_executor = ConcurrentExecutor(
-            *self._longer_io_tasks, *self._short_io_tasks,
+            *self._longer_io_tasks,
+            *self._short_io_tasks,
             wait_for_completion=False,
         )
 
@@ -269,7 +267,6 @@ class TestConcurrentExecutor(TestCase):
         :meth:`ConcurrentExecutor.__enter__` should warn the user. This is
         most likely erroneous API usage.
         """
-
         with pytest.warns(UserWarning, match="is discouraged"):  # noqa: SIM117
             with self._non_blocking_executor:
                 ...
@@ -351,7 +348,6 @@ class TestConcurrentExecutor(TestCase):
         :meth:`ConcurrentExecutor.dispose` should result in the
         :attr:`ConcurrentExecutor.is_disposed` property returning ``True``.
         """
-
         assert not self._blocking_executor.is_disposed
         assert not self._non_blocking_executor.is_disposed
 
@@ -400,7 +396,6 @@ class TestPipe(TestCase):
         :meth:`pipe.execute` should return the value of applying it's input
         value to all it's tasks sequentially.
         """
-
         assert self._instance(0) == "5000"
         assert self._instance(500) == "10000"
         assert self._instance(-500) == "0"
@@ -418,7 +413,6 @@ class TestPipe(TestCase):
         :attr:`pipe.tasks` should return the ``Sequence`` of tasks that
         comprise the ``pipe``.
         """
-
         assert len(self._instance.tasks) == 7
         assert isinstance(self._instance.tasks, Sequence)
         assert isinstance(self._instance.tasks[0], Task)
@@ -451,7 +445,6 @@ class TestTask(TestCase):
         :meth:`Task.of_callable` should return a new ``Task`` instance wrapping
         the given callable.
         """
-
         add_100: Callable[[int], int] = partial(operator.add, 100)
         multiply_by_10: Callable[[int], int] = partial(operator.mul, 10)
 

--- a/test/sghi/typing_tests.py
+++ b/test/sghi/typing_tests.py
@@ -7,7 +7,7 @@ from sghi.typing import Comparable
 from sghi.utils.checkers import ensure_not_none
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing import Self
 
 # =============================================================================
 # COMPARABLE TEST IMPLEMENTATIONS
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 
 class _SimpleComparable(Comparable["_SimpleComparable"]):
-
     __slots__ = ("_value",)
 
     def __init__(self, value: int) -> None:
@@ -54,8 +53,7 @@ class TestComparable(TestCase):
         self._six2: Comparable = _SimpleComparable.of(6)
 
     def test_greater_or_equal_return_value(self) -> None:
-        """
-        The return value of the default implementation of
+        """The return value of the default implementation of
         :meth:`Comparable.__ge__` should return ``True`` when ``a >= b``.
         """
         assert self._five >= self._four
@@ -67,8 +65,7 @@ class TestComparable(TestCase):
         assert not self._five >= self._six1
 
     def test_greater_than_return_value(self) -> None:
-        """
-        The return value of the default implementation of
+        """The return value of the default implementation of
         :meth:`Comparable.__gt__` should return ``True`` when ``a > b``.
         """
         assert self._five > self._four
@@ -80,8 +77,7 @@ class TestComparable(TestCase):
         assert not self._six1 > self._six2
 
     def test_not_equal_return_value(self) -> None:
-        """
-        The return value of the default implementation of
+        """The return value of the default implementation of
         :meth:`Comparable.__ne__` should return ``True`` when ``a != b``.
         """
         assert self._five != self._four

--- a/test/sghi/utils_tests/checkers_tests.py
+++ b/test/sghi/utils_tests/checkers_tests.py
@@ -28,7 +28,6 @@ def test_ensure_greater_or_equal_return_value_on_valid_input() -> None:
     :func:`ensure_greater_or_equal` should return the input value if the given
     ``value`` is greater than or equal to the given ``base_value``.
     """
-
     assert ensure_greater_or_equal(1, 0) == 1
     assert ensure_greater_or_equal(2, 2) == 2
     assert ensure_greater_or_equal(0, -1) == 0
@@ -44,7 +43,6 @@ def test_ensure_greater_or_equal_fails_on_invalid_input() -> None:
     :func:`ensure_greater_or_equal` raises ``ValueError`` when the given
     ``value`` is not greater than or equal to the given ``base_value``.
     """
-
     inputs: Iterable[tuple[Comparable, Comparable]] = (
         (0, 1),
         (-1, 0),
@@ -74,7 +72,6 @@ def test_ensure_greater_than_return_value_on_valid_input() -> None:
     :func:`ensure_greater_than` should return the input value if the given
     ``value`` is greater than the given ``base_value``.
     """
-
     assert ensure_greater_than(1, 0) == 1
     assert ensure_greater_than(0, -1) == 0
     assert ensure_greater_than(-0.0, -1.0) == 0.0
@@ -87,7 +84,6 @@ def test_ensure_greater_than_fails_on_invalid_input() -> None:
     :func:`ensure_greater than` raises ``ValueError`` when the given ``value``
     is not greater than the given ``base_value``.
     """
-
     inputs: Iterable[tuple[Comparable, Comparable]] = (
         (0, 1),
         (2, 2),
@@ -119,7 +115,6 @@ def test_ensure_instance_of_return_value_on_valid_input() -> None:
     :func:`ensure_instance_of` should return the input value if the given
     input value is an instance of the given type.
     """
-
     value: Config = Config.of_proxy()
 
     assert ensure_instance_of(value, Config) is value
@@ -155,7 +150,6 @@ def test_ensure_less_or_equal_return_value_on_valid_input() -> None:
     :func:`ensure_less_ensure_less_or_equal` should return the input value if
     the given ``value`` is less than or equal to the given ``base_value``.
     """
-
     assert ensure_less_or_equal(0, 1) == 0
     assert ensure_less_or_equal(2, 2) == 2
     assert ensure_less_or_equal(-1, 0) == -1
@@ -171,7 +165,6 @@ def test_ensure_less_or_equal_fails_on_invalid_input() -> None:
     :func:`ensure_less_ensure_less_or_equal` raises ``ValueError`` when the
     given ``value`` is not less than or equal to the given ``base_value``.
     """
-
     inputs: Iterable[tuple[Comparable, Comparable]] = (
         (1, 0),
         (0, -1),
@@ -201,7 +194,6 @@ def test_ensure_less_than_return_value_on_valid_input() -> None:
     :func:`ensure_less_than` should return the input value if the given
     ``value`` is less than the given ``base_value``.
     """
-
     assert ensure_less_than(0, 1) == 0
     assert ensure_less_than(-1, 0) == -1
     assert ensure_less_than(-1.0, -0.0) == -1.0
@@ -214,7 +206,6 @@ def test_ensure_less_than_fails_on_invalid_input() -> None:
     :func:`ensure_less_than` raises ``ValueError`` when the given ``value`` is
     not less than the given ``base_value``.
     """
-
     inputs: Iterable[tuple[Comparable, Comparable]] = (
         (1, 0),
         (2, 2),
@@ -310,7 +301,6 @@ def test_ensure_optional_instance_of_return_value_on_valid_input() -> None:
     :func:`ensure_optional_instance_of` should return the input value if the
     given input value is ``None`` or an instance of the given type.
     """
-
     value: Config = Config.of_proxy()
 
     assert ensure_optional_instance_of(None, str) is None

--- a/test/sghi/utils_tests/module_loading_tests.py
+++ b/test/sghi/utils_tests/module_loading_tests.py
@@ -14,13 +14,12 @@ def test_import_string_returns_imported_object_on_valid_input() -> None:
     :func:`import_string` should return the imported Python object when given a
     valid dotted path string.
     """
-
     assert import_string("pytest") is pytest
     assert import_string("sghi.utils:import_string") is import_string
     assert import_string("sghi.utils.others:type_fqn") is type_fqn
     assert (
-            type_fqn(import_string("importlib.metadata:EntryPoint")) ==
-            "importlib.metadata.EntryPoint"
+        type_fqn(import_string("importlib.metadata:EntryPoint"))
+        == "importlib.metadata.EntryPoint"
     )
 
 
@@ -29,7 +28,6 @@ def test_import_string_fails_on_invalid_input() -> None:
     :func:`import_string` should raise an ``ImportError`` when given an invalid
     dotted path string.
     """
-
     invalid_dotted_paths: Iterable[str] = (
         "pytestt",
         "sghi.utils.import_string",  # 'import_string' is not a module
@@ -46,7 +44,6 @@ def test_import_string_fails_on_none_or_empty_input() -> None:
     :func:`import_string` should raise a ``ValueError`` when given a ``None``
     or empty dotted string.
     """
-
     dot_path: str = None  # type: ignore
     invalid_dotted_paths: Iterable[str] = (
         "",
@@ -57,7 +54,9 @@ def test_import_string_fails_on_none_or_empty_input() -> None:
             import_string(dotted_path)
 
 
-def test_import_string_as_klass_returns_imported_object_on_valid_input() -> None:  # noqa: E501
+def test_import_string_as_klass_returns_imported_object_on_valid_input() -> (
+    None
+):
     """
     :func:`import_string_as_klass` should return the imported type when given a
     valid dotted path string.
@@ -74,7 +73,6 @@ def test_import_string_as_klass_fails_on_invalid_dotted_path() -> None:
     :func:`import_import_string_as_klass` should raise an ``ImportError`` when
     given an invalid dotted path string.
     """
-
     invalid_dotted_paths: Iterable[str] = (
         "pytestt",
         "sghi.typing:Compare",  # 'Compare' does not exist
@@ -104,7 +102,6 @@ def test_import_string_as_klass_fails_on_wrong_dotted_path_type() -> None:
     given an invalid dotted path string that doesn't refer to an object of the
     given type.
     """
-
     wrong_inputs: Iterable[tuple[str, type[Any]]] = (
         ("builtins:dict", Sequence),
         ("sghi.disposable:Disposable", Mapping),

--- a/test/sghi/utils_tests/others_tests.py
+++ b/test/sghi/utils_tests/others_tests.py
@@ -7,11 +7,9 @@ from sghi.utils import future_succeeded, type_fqn
 
 
 def test_future_succeeded_fails_on_none_input() -> None:
-    """
-    :func:`future_succeeded` should raise a ``ValueError`` when given a
+    """:func:`future_succeeded` should raise a ``ValueError`` when given a
     ``None`` as it's input.
     """
-
     with pytest.raises(ValueError, match="MUST not be None") as exc_info:
         future_succeeded(None)  # type: ignore
 
@@ -19,8 +17,7 @@ def test_future_succeeded_fails_on_none_input() -> None:
 
 
 def test_future_succeeded_return_value_when_given_cancelled_futures() -> None:
-    """
-    :func:`future_succeeded` should return ``False`` when given a canceled
+    """:func:`future_succeeded` should return ``False`` when given a canceled
     ``Future`` as it's input.
     """
     future: Future[int] = Future()
@@ -30,9 +27,8 @@ def test_future_succeeded_return_value_when_given_cancelled_futures() -> None:
 
 
 def test_future_succeeded_return_value_when_given_failed_futures() -> None:
-    """
-    :func:`future_succeeded` should return ``False`` when given a ``Future``
-     whose callee raised an exception as it's input.
+    """:func:`future_succeeded` should return ``False`` when given a ``Future``
+    whose callee raised an exception as it's input.
     """
     future: Future[int] = Future()
     future.set_exception(ValueError(":("))
@@ -42,9 +38,8 @@ def test_future_succeeded_return_value_when_given_failed_futures() -> None:
 
 
 def test_future_succeeded_return_value_when_given_successful_futures() -> None:
-    """
-    :func:`future_succeeded` should return ``True`` when given a ``Future``
-     that completed without any errors as it's input.
+    """:func:`future_succeeded` should return ``True`` when given a ``Future``
+    that completed without any errors as it's input.
     """
     future: Future[int] = Future()
     future.set_result(10)
@@ -54,19 +49,20 @@ def test_future_succeeded_return_value_when_given_successful_futures() -> None:
 
 
 def test_type_fqn_return_value_on_first_party_types() -> None:
-    """
-    :func:`type_fqn` should return the correct full qualified name when
+    """:func:`type_fqn` should return the correct full qualified name when
     given a first party (part of the current project) type or function.
     """
     assert type_fqn(Disposable) == "sghi.disposable.Disposable"
-    assert type_fqn(ResourceDisposedError) == "sghi.disposable.ResourceDisposedError"  # noqa: E501
+    assert (
+        type_fqn(ResourceDisposedError)
+        == "sghi.disposable.ResourceDisposedError"
+    )
     assert type_fqn(not_disposed) == "sghi.disposable.not_disposed"
     assert type_fqn(type_fqn) == "sghi.utils.others.type_fqn"
 
 
 def test_type_fqn_return_value_on_standard_lib_types() -> None:
-    """
-    :func:`type_fqn` should return the correct full qualified name when
+    """:func:`type_fqn` should return the correct full qualified name when
     given a standard library type or function.
     """
     assert type_fqn(str) == "builtins.str"
@@ -76,11 +72,9 @@ def test_type_fqn_return_value_on_standard_lib_types() -> None:
 
 
 def test_type_fqn_return_value_on_third_party_types() -> None:
-    """
-    :func:`type_fqn` should return the correct full qualified name when
+    """:func:`type_fqn` should return the correct full qualified name when
     given a third party (third party library) type or function.
     """
-
     # FIXME: This might break on upgrade of pytest
     assert type_fqn(pytest.approx) == "_pytest.python_api.approx"
     assert type_fqn(pytest.importorskip) == "_pytest.outcomes.importorskip"
@@ -88,11 +82,9 @@ def test_type_fqn_return_value_on_third_party_types() -> None:
 
 
 def test_type_fqn_fails_on_none_input() -> None:
-    """
-    :func:`type_fqn` should raise a ``ValueError`` when given a ``None`` as
+    """:func:`type_fqn` should raise a ``ValueError`` when given a ``None`` as
     it's input.
     """
-
     with pytest.raises(ValueError, match="MUST not be None") as exc_info:
         type_fqn(None)  # type: ignore
 


### PR DESCRIPTION
Change supported Python versions from `[py310,py311]` to `[py311,py312]`.

Upgrade all dependencies except [coverage](https://github.com/nedbat/coveragepy). At the moment, `coverage` can't be upgraded to a version higher than 6.x as [coveralls-python](https://github.com/TheKevJames/coveralls-python) - a dependency of this project - has an upper bound on the supported `coverage` version. See this [issue](https://github.com/TheKevJames/coveralls-python/issues/373) for details. Moving forward, we should consider dropping `coveralls-python` as a dependency since it no longer appears to be maintained.
