### PR TITLE
fix(types): typing on `Comparable` related checkers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ nitpick_ignore = [
     ("py:class", "sghi.task._IT"),  # private type annotations
     ("py:class", "sghi.task._OT"),  # private type annotations
     ("py:class", "sghi.utils.checkers._Comparable"),  # private type annotations
+    ("py:class", "sghi.utils.checkers._CT"),  # private type annotations
     ("py:class", "sghi.utils.checkers._ST"),  # private type annotations
     ("py:class", "sghi.utils.checkers._T"),  # private type annotations
     ("py:class", "sghi.utils.module_loading._T"),  # private type annotations

--- a/src/sghi/utils/checkers.py
+++ b/src/sghi/utils/checkers.py
@@ -9,6 +9,7 @@ from sghi.typing import Comparable
 # TYPES
 # =============================================================================
 
+_CT = TypeVar("_CT", bound=Comparable)
 _ST = TypeVar("_ST", bound=Sized)
 _T = TypeVar("_T")
 
@@ -19,10 +20,10 @@ _T = TypeVar("_T")
 
 
 def ensure_greater_or_equal(
-    value: Comparable,
+    value: _CT,
     base_value: Comparable,
     message: str = "'value' must be greater than or equal to 'base_value'.",
-) -> Comparable:
+) -> _CT:
     """Check that the given value is greater that or equal to the given base
     value.
 
@@ -45,10 +46,10 @@ def ensure_greater_or_equal(
 
 
 def ensure_greater_than(
-    value: Comparable,
+    value: _CT,
     base_value: Comparable,
     message: str = "'value' must be greater than 'base_value'.",
-) -> Comparable:
+) -> _CT:
     """Check that the given value is greater that the given base value.
 
     If ``value`` is less than or equal to the given ``base_value``, then a
@@ -100,10 +101,10 @@ def ensure_instance_of(
 
 
 def ensure_less_or_equal(
-    value: Comparable,
+    value: _CT,
     base_value: Comparable,
     message: str = "'value' must be less than or equal to 'base_value'.",
-) -> Comparable:
+) -> _CT:
     """Check that the given value is less than or equal the given base value.
 
     If ``value`` is greater than the given ``base_value``, then a
@@ -125,10 +126,10 @@ def ensure_less_or_equal(
 
 
 def ensure_less_than(
-    value: Comparable,
+    value: _CT,
     base_value: Comparable,
     message: str = "'value' must be less than 'base_value'.",
-) -> Comparable:
+) -> _CT:
     """Check that the given value is less that the given base value.
 
     If ``value`` is greater than or equal to the given ``base_value``; then a


### PR DESCRIPTION
Fix typing errors on all checkers that consume `sghi.typing.Comparable`.