### PR TITLE
ci: rename develop release channel from `dev` to `rc`

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,8 +1,8 @@
 branches:
   - main
   - name: develop
-    channel: dev
-    prerelease: dev
+    channel: rc
+    prerelease: rc
 plugins:
   - '@semantic-release/commit-analyzer'
   - - '@semantic-release/release-notes-generator'


### PR DESCRIPTION
This project employs the use of the [setuptools scm](https://setuptools-scm.readthedocs.io/en/latest/) plugin during builds to extract package versions from git. Unfortunately, this plugin forbids tagging dev releases. See this [comment](https://github.com/pypa/setuptools_scm/issues/213#issuecomment-368401550) for more details.

This causes issues when building the project outside the CI where `setuptools_scm` keeps failing when the last tag is a "dev" tag. And although `setuptools_scm` provides a mechanism to [override the version](https://setuptools-scm.readthedocs.io/en/latest/overrides/#pretend-versions) at build, this doesn't work when building with `tox`. This is highly inconvenient as `tox` is handy for running tests and other workflows such as linting and building docs.

From the problem description above, the solution is to change the tagging of the dev releases to something else. I pick *rc*(release candidate), which coincidentally I believe is more appropriate as changes on the develop branch constitute contents of the next major release.