### PR TITLE
chore(patch): explicitly list `sghi.retry` module exports

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -86,5 +86,9 @@ releaseRules:
     release: minor
   - type: fix
     release: patch
+  - scope: minor
+    release: minor
+  - scope: patch
+    release: patch
   - scope: no-release
     release: false

--- a/src/sghi/retry/__init__.py
+++ b/src/sghi/retry/__init__.py
@@ -436,3 +436,17 @@ class _NoOpRetry(Retry):
 exponential_backoff_retry = Retry.of_exponential_backoff
 
 noop_retry = Retry.of_noop
+
+
+# =============================================================================
+# MODULE EXPORTS
+# =============================================================================
+
+__all__ = [
+    "Retry",
+    "RetryError",
+    "exponential_backoff_retry",
+    "if_exception_type_factory",
+    "if_transient_exception",
+    "noop_retry",
+]


### PR DESCRIPTION
Explicitly list the module exports for the `sghi.retry` module.