### PR TITLE
feat(task): add an identity `Task` factory

### DIFF
--- a/src/sghi/task/__init__.py
+++ b/src/sghi/task/__init__.py
@@ -12,7 +12,7 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     wait,
 )
-from functools import reduce, update_wrapper
+from functools import cache, reduce, update_wrapper
 from logging import Logger, getLogger
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, final, overload
 
@@ -283,6 +283,23 @@ class Task(Generic[_IT, _OT], metaclass=ABCMeta):
         """
         # FIXME: rename 'source_callable' to 'target_callable' instead.
         return _OfCallable(source_callable=source_callable)
+
+    @staticmethod
+    @cache
+    def of_identity() -> Task[_IT, _IT]:
+        """Return a  :class:`~sghi.task.Task` that always returns its input.
+
+        The returned ``Task`` always returns its input argument as is.
+
+        .. note::
+
+            The instances returned by this method are NOT guaranteed to be
+            distinct on each invocation.
+
+        :return: A ``Task`` instance that always returns its input argument
+            as is.
+        """
+        return _OfCallable(source_callable=lambda _v: _v)
 
 
 # =============================================================================

--- a/test/sghi/task_tests.py
+++ b/test/sghi/task_tests.py
@@ -675,3 +675,17 @@ class TestTask(TestCase):
 
         assert add_100(-100) == task1(-100) == 0
         assert multiply_by_10(100) == task2(100) == 1000
+
+    def test_of_identity_method_returns_expected_value(self) -> None:
+        """
+        :meth:`Task.of_identity` should return a ``Task`` instance that always
+        returns its input value as is.
+        """
+
+        a_reference: list[int] = list(range(5))
+
+        assert isinstance(Task.of_identity(), Task)
+        assert Task.of_identity()(5) == 5
+        assert Task.of_identity()("Hello, World!!") == "Hello, World!!"
+        assert Task.of_identity()(None) is None
+        assert Task.of_identity()(a_reference) is a_reference


### PR DESCRIPTION
Add a factory method on the `Task` class, `sghi.task.Task.of_identity`. This returns identity `Task` instances that always return their input argument as is when invoked.